### PR TITLE
feat(onboarding): conversational wizard + demo mode (task 19, model b)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,11 +36,18 @@ uv run pytest
 
 Svelte + Vite in `dashboard/`; FastAPI serves the built assets at `/` with the API at `/v1/`. Requires Node 22+.
 
-**Seed a login (once per customer):**
+**Provision a customer (creates the dashboard login):**
 ```bash
-uv run scripts/seed_dashboard_auth.py demo_jewelry
-# → prints the generated secret; use customer_id + secret at the login form
+curl -X POST :8000/v1/customers/provision -d '{"customer_id":"demo_jewelry"}'
+# → {customer_id, token, dashboard_secret} — use customer_id + secret at the login form
 ```
+
+Add `"demo": true` to the body to skip the onboarding wizard and
+pre-populate settings, notifications, activity counters, and sample
+conversations — useful for prospect eval or screenshot prep.
+
+`scripts/seed_dashboard_auth.py <customer_id>` still works for
+re-keying an existing customer without re-provisioning.
 
 **Full stack (built assets, one process):**
 ```bash

--- a/src/agents/executive_assistant.py
+++ b/src/agents/executive_assistant.py
@@ -1571,6 +1571,56 @@ The key difference: automation tools give you software to configure. I give you 
         except Exception as e:
             logger.warning(f"Personality load failed, using defaults: {e}")
 
+    async def _maybe_onboard(self, message: str) -> Optional[str]:
+        """Route to onboarding flow if incomplete. Returns the flow's
+        reply, or None to signal 'proceed with normal handling'.
+
+        Interrupt handling: if the message looks like a real task
+        request, hand it to the normal graph and append a gentle
+        'we can finish setup later' note. The flow state doesn't
+        advance — next non-task message resumes where they left off.
+        """
+        if self.settings_redis is None:
+            return None
+        try:
+            from src.onboarding.flow import OnboardingFlow
+            from src.onboarding.state import OnboardingStateStore
+
+            store = OnboardingStateStore(self.settings_redis)
+            if await store.is_complete(self.customer_id):
+                return None
+
+            flow = OnboardingFlow(
+                state_store=store,
+                settings_redis=self.settings_redis,
+                personality=self._personality,
+            )
+
+            state = await store.get(self.customer_id)
+            if state.status == "in_progress" and flow.looks_like_real_request(message):
+                # Customer is clearly using the system — handle their
+                # request, note that setup can resume later. Returning
+                # None lets the normal graph run; we append the note
+                # via a post-hook flag.
+                self._onboarding_interrupted = True
+                return None
+
+            return await flow.handle(self.customer_id, message)
+        except Exception as e:
+            # Onboarding is a nicety. A Redis blip or import error
+            # must not block the customer from using the EA.
+            logger.warning(f"Onboarding check failed, skipping: {e}")
+            return None
+
+    def _track_history(self, conversation_id: str, message: str, response: str) -> None:
+        self._conversation_histories.setdefault(conversation_id, [])
+        self._conversation_histories[conversation_id].append(
+            {"role": "human", "content": message, "timestamp": datetime.now().isoformat()}
+        )
+        self._conversation_histories[conversation_id].append(
+            {"role": "ai", "content": response, "timestamp": datetime.now().isoformat()}
+        )
+
     async def _record_delegation_start(
         self, conversation_id: str, domain: str,
     ) -> str | None:
@@ -1772,6 +1822,15 @@ The key difference: automation tools give you software to configure. I give you 
             # don't each hit Redis.
             await self._load_personality()
 
+            # Onboarding gate. First-run customers get the guided setup
+            # wizard instead of normal delegation. Once complete this is
+            # one cheap Redis GET per turn. No settings_redis → legacy
+            # path, skip the check entirely.
+            onboarding_reply = await self._maybe_onboard(message)
+            if onboarding_reply is not None:
+                self._track_history(conversation_id, message, onboarding_reply)
+                return onboarding_reply
+
             # Get business context
             business_context = await self.memory.get_business_context()
 
@@ -1853,6 +1912,15 @@ The key difference: automation tools give you software to configure. I give you 
             self._conversation_histories[conversation_id].append(
                 {"role": "ai", "content": response, "timestamp": datetime.now().isoformat()}
             )
+
+            # Onboarding was interrupted by a real request — append a
+            # gentle note so the customer knows setup can resume.
+            if getattr(self, "_onboarding_interrupted", False):
+                self._onboarding_interrupted = False
+                response += (
+                    "\n\n(We can finish setup later — just say 'continue "
+                    "setup' or I'll pick back up next time.)"
+                )
 
             logger.info(f"Enhanced EA handled interaction for customer {self.customer_id} via {channel.value}")
 

--- a/src/api/routes/provisioning.py
+++ b/src/api/routes/provisioning.py
@@ -2,23 +2,34 @@
 Customer provisioning — wraps InfrastructureOrchestrator.
 
 POST /v1/customers/provision
-  body: {customer_id?, tier?}
+  body: {customer_id?, tier?, demo?}
   auth: none (this *creates* the auth token)
-  → {customer_id, token, tier}
+  → {customer_id, token, tier, dashboard_secret}
 
 We don't re-implement provisioning logic. The orchestrator owns the
 Docker-network creation, port allocation, service deployment. We mint a
 customer_id if one wasn't supplied, call the orchestrator, and hand back
 a token.
+
+After infra provisioning succeeds we seed Redis so the customer can
+message the EA and log into the dashboard with zero manual steps:
+  - default Settings (or demo-configured ones)
+  - onboarding state (not_started, or completed for demo)
+  - auth secret for dashboard login
+
+Seeding is best-effort — a Redis blip logs a warning but the customer
+still gets their token. Infra provisioning is the critical path; seeding
+is a convenience that can be done manually if it fails.
 """
 import logging
+import secrets
 import uuid
 
 from fastapi import APIRouter, Request, status
 
 from ..auth import create_token
 from ..errors import BadRequestError, ServiceUnavailableError
-from ..schemas import ProvisionRequest, ProvisionResponse
+from ..schemas import ProvisionRequest, ProvisionResponse, Settings
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/customers", tags=["provisioning"])
@@ -59,9 +70,42 @@ async def provision_customer(req: ProvisionRequest, request: Request):
         )
 
     token = create_token(customer_id)
+    dashboard_secret = await _seed(request, customer_id, demo=req.demo)
 
     return ProvisionResponse(
         customer_id=env.customer_id,
         token=token,
         tier=env.tier,
+        dashboard_secret=dashboard_secret,
     )
+
+
+async def _seed(request: Request, customer_id: str, *, demo: bool) -> str | None:
+    """Best-effort Redis seeding. Returns the dashboard secret on
+    success, None on failure. Never raises — seeding failure is not a
+    provisioning failure."""
+    redis = getattr(request.app.state, "redis_client", None)
+    if redis is None:
+        return None
+    try:
+        secret = secrets.token_urlsafe(24)
+        await redis.set(f"auth:{customer_id}:secret", secret)
+
+        if demo:
+            from src.onboarding.demo_seed import seed_demo_account
+            repo = getattr(request.app.state, "conversation_repo", None)
+            await seed_demo_account(redis, customer_id, conversation_repo=repo)
+        else:
+            from src.onboarding.state import OnboardingStateStore
+            await redis.set(
+                f"settings:{customer_id}", Settings().model_dump_json(),
+            )
+            await OnboardingStateStore(redis).initialize(customer_id)
+
+        return secret
+    except Exception as e:
+        logger.warning(
+            "Post-provision seeding failed for customer=%s: %s",
+            customer_id, e,
+        )
+        return None

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -51,12 +51,19 @@ class ProvisionRequest(BaseModel):
                     "Omit to auto-generate.",
     )
     tier: Tier = "professional"
+    # Demo mode: skip onboarding, pre-populate sample conversations,
+    # notifications, and configured settings so the dashboard has
+    # content in every section. For prospect evaluation.
+    demo: bool = False
 
 
 class ProvisionResponse(BaseModel):
     customer_id: str
     token: str
     tier: Tier
+    # Pre-shared key for POST /v1/auth/login. None if seeding failed
+    # (Redis unavailable) — the customer can still use the JWT token.
+    dashboard_secret: Optional[str] = None
 
 
 class HistoryMessage(BaseModel):

--- a/src/onboarding/__init__.py
+++ b/src/onboarding/__init__.py
@@ -1,0 +1,28 @@
+"""
+Conversational onboarding wizard.
+
+A 4-step guided exchange the EA runs for new customers before normal
+routing kicks in. State persists in Redis at ``onboarding:{customer_id}``
+so dropped-off customers resume where they left off.
+
+Not to be confused with infrastructure provisioning (LAUNCH-Bot) — that
+creates the customer's MCP server and EA instance; this teaches the
+already-running EA who the customer is.
+
+Public API:
+    OnboardingFlow        — drives the conversation, one turn per handle()
+    OnboardingStateStore  — Redis-backed step/status tracking
+    OnboardingStep        — step enum (INTRO … DONE)
+    seed_demo_account     — populate a fresh account with sample data
+"""
+from .demo_seed import seed_demo_account
+from .flow import OnboardingFlow
+from .state import OnboardingState, OnboardingStateStore, OnboardingStep
+
+__all__ = [
+    "OnboardingFlow",
+    "OnboardingState",
+    "OnboardingStateStore",
+    "OnboardingStep",
+    "seed_demo_account",
+]

--- a/src/onboarding/demo_seed.py
+++ b/src/onboarding/demo_seed.py
@@ -1,0 +1,146 @@
+"""
+Demo account seeding — realistic sample data for prospect evaluation.
+
+Populates everything the dashboard reads so every card has content:
+  - settings (configured hours, briefing on, friendly tone)
+  - onboarding state (completed — demo users skip the wizard)
+  - notifications (morning briefing, finance alert, workflow status)
+  - activity counters (messages + delegations for today's card)
+  - conversations (3-5 exchanges across specialist domains, if a
+    Postgres repo is provided)
+
+All keys are customer-scoped. Called by the provisioning endpoint when
+``demo=true``.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+from src.api.schemas import Settings, WorkingHours, BriefingSettings, PersonalitySettings
+from src.proactive.state import ProactiveStateStore
+
+from .state import OnboardingStateStore
+
+
+async def seed_demo_account(
+    redis_client,
+    customer_id: str,
+    *,
+    conversation_repo=None,
+) -> None:
+    await _seed_settings(redis_client, customer_id)
+    await _mark_onboarded(redis_client, customer_id)
+    await _seed_notifications(redis_client, customer_id)
+    await _seed_activity(redis_client, customer_id)
+    if conversation_repo is not None:
+        await _seed_conversations(conversation_repo, customer_id)
+
+
+async def _seed_settings(redis, customer_id: str) -> None:
+    settings = Settings(
+        working_hours=WorkingHours(
+            start="08:30", end="17:30", timezone="America/New_York",
+        ),
+        briefing=BriefingSettings(enabled=True, time="08:00"),
+        personality=PersonalitySettings(
+            tone="friendly", language="en", name="Sarah",
+        ),
+    )
+    await redis.set(f"settings:{customer_id}", settings.model_dump_json())
+
+
+async def _mark_onboarded(redis, customer_id: str) -> None:
+    store = OnboardingStateStore(redis)
+    await store.complete(customer_id)
+
+
+async def _seed_notifications(redis, customer_id: str) -> None:
+    store = ProactiveStateStore(redis)
+    now = datetime.now(timezone.utc)
+    samples = [
+        {
+            "domain": "scheduling",
+            "trigger_type": "briefing",
+            "priority": "MEDIUM",
+            "title": "Morning briefing",
+            "message": "3 meetings today. First at 10:00 with Acme Corp.",
+            "created_at": (now - timedelta(hours=2)).isoformat(),
+        },
+        {
+            "domain": "finance",
+            "trigger_type": "anomaly",
+            "priority": "HIGH",
+            "title": "Unusual expense detected",
+            "message": "$2,400 software charge — 3× your monthly average.",
+            "created_at": (now - timedelta(hours=1)).isoformat(),
+        },
+        {
+            "domain": "workflows",
+            "trigger_type": "status",
+            "priority": "LOW",
+            "title": "Weekly report generated",
+            "message": "Your weekly summary automation ran successfully.",
+            "created_at": (now - timedelta(minutes=30)).isoformat(),
+        },
+    ]
+    for n in samples:
+        await store.add_pending_notification(customer_id, n)
+
+
+async def _seed_activity(redis, customer_id: str) -> None:
+    today = date.today().isoformat()
+    ttl = 48 * 3600
+    # Message count
+    await redis.set(f"activity:{customer_id}:messages:{today}", 12, ex=ttl)
+    # Delegations across domains — enough variety to show the chart
+    for domain, count in (("scheduling", 4), ("finance", 3), ("workflows", 2)):
+        await redis.set(
+            f"activity:{customer_id}:delegation:{domain}:{today}", count, ex=ttl,
+        )
+
+
+# Sample exchanges. Each tuple: (channel, [(role, content, domain?), ...]).
+# Domains tag assistant messages so the dashboard's specialist-activity
+# view has data. User messages have no domain.
+_SAMPLE_CONVERSATIONS = [
+    ("whatsapp", [
+        ("user", "Can you move my 3pm with Jordan to Thursday?", None),
+        ("assistant", "Done — moved to Thursday 3:00 PM. Jordan's been notified.",
+         "scheduling"),
+    ]),
+    ("whatsapp", [
+        ("user", "What did we spend on software last month?", None),
+        ("assistant", "$1,840 across 6 vendors. Biggest: AWS at $620. "
+         "Want the full breakdown?", "finance"),
+    ]),
+    ("chat", [
+        ("user", "Set up a weekly summary of new leads", None),
+        ("assistant", "Created a workflow that pulls new leads every Friday "
+         "at 5pm and emails you the summary. It's live now.", "workflows"),
+    ]),
+    ("whatsapp", [
+        ("user", "How's engagement on the product launch post?", None),
+        ("assistant", "Up 34% vs. your average — 2.1k impressions, 180 likes, "
+         "42 shares. Best-performing post this quarter.", "social_media"),
+    ]),
+]
+
+
+async def _seed_conversations(repo, customer_id: str) -> None:
+    for channel, messages in _SAMPLE_CONVERSATIONS:
+        conv_id = f"demo_{uuid.uuid4().hex[:12]}"
+        await repo.create_conversation(
+            customer_id=customer_id,
+            conversation_id=conv_id,
+            channel=channel,
+        )
+        for role, content, domain in messages:
+            await repo.append_message(
+                customer_id=customer_id,
+                conversation_id=conv_id,
+                role=role,
+                content=content,
+                specialist_domain=domain,
+            )

--- a/src/onboarding/demo_seed.py
+++ b/src/onboarding/demo_seed.py
@@ -6,7 +6,7 @@ Populates everything the dashboard reads so every card has content:
   - onboarding state (completed — demo users skip the wizard)
   - notifications (morning briefing, finance alert, workflow status)
   - activity counters (messages + delegations for today's card)
-  - conversations (3-5 exchanges across specialist domains, if a
+  - conversations (sample exchanges across specialist domains, if a
     Postgres repo is provided)
 
 All keys are customer-scoped. Called by the provisioning endpoint when

--- a/src/onboarding/flow.py
+++ b/src/onboarding/flow.py
@@ -1,0 +1,264 @@
+"""
+Onboarding flow — the 5-step guided conversation.
+
+Each ``handle()`` call consumes one customer message and returns one EA
+reply (or None once onboarding is complete — signals the caller to route
+normally). State lives in OnboardingStateStore so the flow survives
+process restarts and dropped conversations.
+
+The flow writes directly to ``settings:{customer_id}`` — the same key
+the dashboard PUT /v1/settings endpoint owns. That's deliberate: there's
+one source of truth for settings, and onboarding is just another writer.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Dict, Optional
+
+from src.api.schemas import Settings
+
+from .state import OnboardingStateStore, OnboardingStep
+
+# Timezone abbreviations → IANA names. Not exhaustive — covers the
+# common US zones customers actually say out loud. Anything else
+# passes through as-is (UTC, Europe/London) or falls back to default.
+_TZ_ALIASES = {
+    "eastern": "America/New_York",
+    "est": "America/New_York",
+    "edt": "America/New_York",
+    "central": "America/Chicago",
+    "cst": "America/Chicago",
+    "mountain": "America/Denver",
+    "mst": "America/Denver",
+    "pacific": "America/Los_Angeles",
+    "pst": "America/Los_Angeles",
+    "pdt": "America/Los_Angeles",
+}
+
+# Business-type → quick-win suggestion. Keyword match on the free-text
+# business context. Order matters — first match wins.
+_QUICK_WINS = [
+    (("restaurant", "cafe", "bar", "diner", "bistro"),
+     "Want me to set up a daily reservation summary each morning?"),
+    (("consult", "agency", "law", "firm", "advisor"),
+     "I can send you a morning briefing with today's meetings and any "
+     "follow-ups due. Want me to turn that on?"),
+    (("retail", "shop", "store", "ecommerce", "jewelry"),
+     "Want me to send a daily sales and inventory check-in?"),
+]
+_GENERIC_QUICK_WIN = (
+    "Want me to send you a morning briefing each day with your schedule "
+    "and any updates?"
+)
+
+# Interrupt detection — imperative verbs that signal "actually do
+# something" rather than answering an onboarding question. Deliberately
+# conservative: false negatives (missing an interrupt) are fine because
+# the customer can just repeat themselves after onboarding; false
+# positives (treating "I run a scheduling business" as a scheduling
+# request) break the flow.
+_INTERRUPT_PATTERNS = [
+    r"\b(schedule|book|set up|create|cancel|reschedule)\b.*\b(meeting|call|appointment|event)\b",
+    r"\b(send|draft|write)\b.*\b(email|message|invoice)\b",
+    r"\b(add|log|record|track)\b.*\b(expense|transaction|payment)\b",
+    r"\bremind me\b",
+    r"^actually\b",
+]
+
+
+class OnboardingFlow:
+    def __init__(
+        self,
+        *,
+        state_store: OnboardingStateStore,
+        settings_redis,
+        personality: Dict[str, str],
+    ) -> None:
+        self._store = state_store
+        self._settings_redis = settings_redis
+        self._personality = personality
+
+    async def handle(self, customer_id: str, message: str) -> Optional[str]:
+        """Process one turn. Returns the EA's reply, or None if
+        onboarding is already complete (caller should route normally)."""
+        state = await self._store.get(customer_id)
+
+        if state.status == "completed":
+            return None
+
+        if state.step == OnboardingStep.INTRO:
+            return await self._intro(customer_id)
+
+        if state.step == OnboardingStep.BUSINESS_CONTEXT:
+            return await self._business_context(customer_id, message)
+
+        if state.step == OnboardingStep.PREFERENCES:
+            return await self._preferences(customer_id, message)
+
+        if state.step == OnboardingStep.QUICK_WIN:
+            return await self._quick_win(customer_id, message)
+
+        # Shouldn't reach — DONE implies status==completed
+        return None
+
+    def looks_like_real_request(self, message: str) -> bool:
+        """Heuristic: does this look like a task request rather than an
+        onboarding answer? Caller decides whether to interrupt the flow."""
+        lowered = message.lower()
+        return any(re.search(p, lowered) for p in _INTERRUPT_PATTERNS)
+
+    # ─── steps ───────────────────────────────────────────────────────────
+
+    async def _intro(self, customer_id: str) -> str:
+        name = self._personality.get("name", "Assistant")
+        await self._store.advance(customer_id, OnboardingStep.BUSINESS_CONTEXT)
+        return (
+            f"Hi! I'm {name}, your executive assistant. I can manage your "
+            f"scheduling, track finances, automate workflows, and "
+            f"proactively keep you informed. "
+            f"To get started — what kind of business do you run?"
+        )
+
+    async def _business_context(self, customer_id: str, message: str) -> str:
+        await self._store.advance(
+            customer_id,
+            OnboardingStep.PREFERENCES,
+            collected={"business_context": message.strip()},
+        )
+        return (
+            "Got it. What are your working hours and timezone? "
+            "(e.g. '9 to 5 Eastern' — or just say 'skip' and I'll use "
+            "sensible defaults.)"
+        )
+
+    async def _preferences(self, customer_id: str, message: str) -> str:
+        hours = _parse_working_hours(message)
+        used_defaults = hours is None
+        settings = await self._load_settings(customer_id)
+        if hours:
+            settings.working_hours.start = hours["start"]
+            settings.working_hours.end = hours["end"]
+            if hours.get("timezone"):
+                settings.working_hours.timezone = hours["timezone"]
+        await self._save_settings(customer_id, settings)
+
+        state = await self._store.get(customer_id)
+        suggestion = _pick_quick_win(state.collected.get("business_context", ""))
+        await self._store.advance(
+            customer_id, OnboardingStep.QUICK_WIN,
+            collected={"quick_win_offered": suggestion},
+        )
+
+        prefix = ""
+        if used_defaults:
+            prefix = ("No problem — I'll use 9-to-6 for now. You can change "
+                      "it anytime from the dashboard. ")
+        return f"{prefix}One more thing: {suggestion}"
+
+    async def _quick_win(self, customer_id: str, message: str) -> str:
+        accepted = _is_affirmative(message)
+        if accepted:
+            settings = await self._load_settings(customer_id)
+            settings.briefing.enabled = True
+            await self._save_settings(customer_id, settings)
+            confirm = "Done — you'll get your first briefing tomorrow morning. "
+        else:
+            confirm = "No problem, you can turn it on later. "
+
+        await self._store.complete(customer_id)
+        return (
+            f"{confirm}You're all set — message me anytime. "
+            f"The dashboard has more configuration if you want to tweak "
+            f"anything."
+        )
+
+    # ─── settings I/O ────────────────────────────────────────────────────
+
+    async def _load_settings(self, customer_id: str) -> Settings:
+        raw = await self._settings_redis.get(f"settings:{customer_id}")
+        if raw is None:
+            return Settings()
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return Settings.model_validate(json.loads(raw))
+
+    async def _save_settings(self, customer_id: str, settings: Settings) -> None:
+        await self._settings_redis.set(
+            f"settings:{customer_id}", settings.model_dump_json()
+        )
+
+
+# ─── parsing helpers ─────────────────────────────────────────────────────
+
+_HOUR_PATTERNS = [
+    # "9 to 5", "9am to 5pm", "9:30 to 17:00"
+    re.compile(
+        r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*(?:to|-|–|until)\s*"
+        r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)?",
+        re.IGNORECASE,
+    ),
+]
+
+
+def _parse_working_hours(text: str) -> Optional[Dict[str, str]]:
+    for pat in _HOUR_PATTERNS:
+        m = pat.search(text)
+        if not m:
+            continue
+        sh, sm, sap, eh, em, eap = m.groups()
+        start = _to_24h(int(sh), int(sm or 0), sap)
+        end = _to_24h(int(eh), int(em or 0), eap)
+        if start is None or end is None:
+            continue
+        result = {"start": start, "end": end}
+        tz = _extract_tz(text)
+        if tz:
+            result["timezone"] = tz
+        return result
+    return None
+
+
+def _to_24h(hour: int, minute: int, ampm: Optional[str]) -> Optional[str]:
+    if ampm:
+        ampm = ampm.lower()
+        if ampm == "pm" and hour < 12:
+            hour += 12
+        elif ampm == "am" and hour == 12:
+            hour = 0
+    # Heuristic: bare hours ≤ 7 without am/pm are probably pm in a
+    # work-hours context ("9 to 5" → 09:00–17:00, not 05:00).
+    elif hour <= 7:
+        hour += 12
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        return None
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _extract_tz(text: str) -> Optional[str]:
+    lowered = text.lower()
+    for alias, iana in _TZ_ALIASES.items():
+        if alias in lowered:
+            return iana
+    # Pass through explicit IANA-ish tokens or UTC
+    m = re.search(r"\b(UTC|[A-Z][a-z]+/[A-Z][a-z_]+)\b", text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _pick_quick_win(business_context: str) -> str:
+    lowered = business_context.lower()
+    for keywords, suggestion in _QUICK_WINS:
+        if any(k in lowered for k in keywords):
+            return suggestion
+    return _GENERIC_QUICK_WIN
+
+
+def _is_affirmative(text: str) -> bool:
+    lowered = text.lower().strip()
+    return any(
+        w in lowered
+        for w in ("yes", "yeah", "sure", "ok", "okay", "please", "sounds good",
+                  "do it", "go ahead", "yep")
+    ) and not any(w in lowered for w in ("no", "not", "later", "skip"))

--- a/src/onboarding/flow.py
+++ b/src/onboarding/flow.py
@@ -1,5 +1,6 @@
 """
-Onboarding flow — the 5-step guided conversation.
+Onboarding flow — 4-step guided conversation (intro → business context
+→ preferences → quick win).
 
 Each ``handle()`` call consumes one customer message and returns one EA
 reply (or None once onboarding is complete — signals the caller to route

--- a/src/onboarding/state.py
+++ b/src/onboarding/state.py
@@ -1,0 +1,98 @@
+"""
+Onboarding state — Redis-backed per-customer wizard progress.
+
+Key: ``onboarding:{customer_id}`` → JSON {status, step, collected}
+
+State machine: not_started → in_progress → completed. The EA checks
+``is_complete`` at the top of every interaction; anything other than
+completed routes to the onboarding flow instead of normal delegation.
+
+Step tracking lets a customer who drops off mid-flow resume where they
+left off. ``collected`` is a scratch dict the flow uses to stash
+answers (business context, timezone) before writing them to their
+final homes (settings, customer metadata).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict
+
+
+class OnboardingStep(str, Enum):
+    INTRO = "intro"
+    BUSINESS_CONTEXT = "business_context"
+    PREFERENCES = "preferences"
+    QUICK_WIN = "quick_win"
+    DONE = "done"
+
+
+@dataclass
+class OnboardingState:
+    status: str = "not_started"      # not_started | in_progress | completed
+    step: OnboardingStep = OnboardingStep.INTRO
+    collected: Dict[str, Any] = field(default_factory=dict)
+
+
+def _key(customer_id: str) -> str:
+    return f"onboarding:{customer_id}"
+
+
+class OnboardingStateStore:
+    def __init__(self, redis_client) -> None:
+        self._r = redis_client
+
+    async def get(self, customer_id: str) -> OnboardingState:
+        raw = await self._r.get(_key(customer_id))
+        if raw is None:
+            return OnboardingState()
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        data = json.loads(raw)
+        return OnboardingState(
+            status=data.get("status", "not_started"),
+            step=OnboardingStep(data.get("step", OnboardingStep.INTRO.value)),
+            collected=data.get("collected", {}),
+        )
+
+    async def initialize(self, customer_id: str) -> None:
+        """Seed not_started state. Idempotent — never resets a customer
+        who has already progressed or completed."""
+        existing = await self.get(customer_id)
+        if existing.status != "not_started":
+            return
+        await self._write(customer_id, OnboardingState())
+
+    async def advance(
+        self,
+        customer_id: str,
+        step: OnboardingStep,
+        *,
+        collected: Dict[str, Any] | None = None,
+    ) -> None:
+        state = await self.get(customer_id)
+        state.status = "in_progress"
+        state.step = step
+        if collected:
+            state.collected.update(collected)
+        await self._write(customer_id, state)
+
+    async def complete(self, customer_id: str) -> None:
+        state = await self.get(customer_id)
+        state.status = "completed"
+        state.step = OnboardingStep.DONE
+        await self._write(customer_id, state)
+
+    async def is_complete(self, customer_id: str) -> bool:
+        return (await self.get(customer_id)).status == "completed"
+
+    async def _write(self, customer_id: str, state: OnboardingState) -> None:
+        await self._r.set(
+            _key(customer_id),
+            json.dumps({
+                "status": state.status,
+                "step": state.step.value,
+                "collected": state.collected,
+            }),
+        )

--- a/tests/unit/api/test_provisioning_seed.py
+++ b/tests/unit/api/test_provisioning_seed.py
@@ -144,8 +144,10 @@ class TestDemoMode:
 
         raw = await _read(fake_server, "settings:demo_acme")
         settings = json.loads(raw)
+        # tone defaults to "professional" — this proves demo seeding
+        # wrote non-default values. (briefing.enabled defaults to True,
+        # so asserting on it would be happy-green.)
         assert settings["personality"]["tone"] == "friendly"
-        assert settings["briefing"]["enabled"] is True
 
     async def test_demo_false_uses_normal_seeding(
         self, mock_orchestrator, fake_server

--- a/tests/unit/api/test_provisioning_seed.py
+++ b/tests/unit/api/test_provisioning_seed.py
@@ -1,0 +1,181 @@
+"""
+Provisioning enhancement — seed defaults so a freshly provisioned
+customer can message the EA AND log into the dashboard with zero
+manual steps.
+
+Added behaviour on POST /v1/customers/provision:
+  - settings:{customer_id}      — default Settings written to Redis
+  - onboarding:{customer_id}    — initialized to not_started
+  - auth:{customer_id}:secret   — random dashboard secret, returned
+                                  in response body
+
+Demo mode (demo=true in request):
+  - runs seed_demo_account instead
+  - onboarding marked completed
+  - sample notifications + activity + settings populated
+
+FakeServer note: TestClient runs the app in its own event loop (anyio
+portal). Verification runs in pytest-asyncio's loop. A FakeRedis
+instance binds its queue to whichever loop first awaits it, so the app
+and the verification step need separate clients backed by the same
+FakeServer — shared data, no loop crossing.
+"""
+import json
+
+import pytest
+import fakeredis
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+
+from src.api.app import create_app
+from src.api.ea_registry import EARegistry
+
+
+@pytest.fixture
+def fake_server():
+    return fakeredis.FakeServer()
+
+
+def _app(orchestrator, server, conversation_repo=None):
+    # Fresh client for the app — binds to TestClient's event loop.
+    redis = fakeredis.aioredis.FakeRedis(server=server)
+    return create_app(
+        ea_registry=EARegistry(factory=MagicMock()),
+        orchestrator=orchestrator,
+        whatsapp_manager=MagicMock(),
+        redis_client=redis,
+        conversation_repo=conversation_repo,
+    )
+
+
+async def _read(server, key, *, hash=False):
+    """Read from the shared FakeServer on the test body's loop."""
+    r = fakeredis.aioredis.FakeRedis(server=server)
+    return await (r.hgetall(key) if hash else r.get(key))
+
+
+class TestDefaultSeeding:
+    async def test_seeds_default_settings(self, mock_orchestrator, fake_server):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        resp = client.post("/v1/customers/provision",
+                           json={"customer_id": "cust_fresh", "tier": "basic"})
+
+        assert resp.status_code == 201
+        raw = await _read(fake_server, "settings:cust_fresh")
+        settings = json.loads(raw)
+        assert settings["working_hours"]["start"] == "09:00"
+        assert settings["personality"]["name"] == "Assistant"
+
+    async def test_initializes_onboarding_state(self, mock_orchestrator, fake_server):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "cust_fresh", "tier": "basic"})
+
+        raw = await _read(fake_server, "onboarding:cust_fresh")
+        state = json.loads(raw)
+        assert state["status"] == "not_started"
+
+    async def test_creates_dashboard_auth_secret(self, mock_orchestrator, fake_server):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        resp = client.post("/v1/customers/provision",
+                           json={"customer_id": "cust_fresh", "tier": "basic"})
+
+        body = resp.json()
+        assert body["dashboard_secret"]
+        assert len(body["dashboard_secret"]) >= 20
+
+        stored = await _read(fake_server, "auth:cust_fresh:secret")
+        assert stored.decode() == body["dashboard_secret"]
+
+    def test_seeding_failure_does_not_block_provision(self, mock_orchestrator):
+        """Redis down during seeding → customer still gets their token.
+        Seeding is best-effort; infra provisioning is the critical path."""
+        broken = AsyncMock()
+        broken.set = AsyncMock(side_effect=ConnectionError("redis down"))
+        broken.get = AsyncMock(side_effect=ConnectionError("redis down"))
+        app = create_app(
+            ea_registry=EARegistry(factory=MagicMock()),
+            orchestrator=mock_orchestrator,
+            whatsapp_manager=MagicMock(),
+            redis_client=broken,
+        )
+        client = TestClient(app)
+
+        resp = client.post("/v1/customers/provision", json={"tier": "basic"})
+
+        assert resp.status_code == 201
+        assert resp.json()["token"]
+        assert resp.json()["dashboard_secret"] is None
+
+
+class TestDemoMode:
+    async def test_demo_flag_marks_onboarding_complete(
+        self, mock_orchestrator, fake_server
+    ):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "demo_acme", "tier": "basic",
+                          "demo": True})
+
+        raw = await _read(fake_server, "onboarding:demo_acme")
+        state = json.loads(raw)
+        assert state["status"] == "completed"
+
+    async def test_demo_seeds_notifications(self, mock_orchestrator, fake_server):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "demo_acme", "demo": True})
+
+        notifs = await _read(fake_server, "proactive:demo_acme:notifications",
+                             hash=True)
+        assert len(notifs) >= 3
+
+    async def test_demo_seeds_friendly_settings(self, mock_orchestrator, fake_server):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "demo_acme", "demo": True})
+
+        raw = await _read(fake_server, "settings:demo_acme")
+        settings = json.loads(raw)
+        assert settings["personality"]["tone"] == "friendly"
+        assert settings["briefing"]["enabled"] is True
+
+    async def test_demo_false_uses_normal_seeding(
+        self, mock_orchestrator, fake_server
+    ):
+        client = TestClient(_app(mock_orchestrator, fake_server))
+
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "cust_real", "demo": False})
+
+        raw = await _read(fake_server, "onboarding:cust_real")
+        state = json.loads(raw)
+        assert state["status"] == "not_started"  # not demo-completed
+
+    def test_demo_seeds_conversations_when_repo_available(
+        self, mock_orchestrator, fake_server
+    ):
+        created = []
+
+        class FakeRepo:
+            async def create_conversation(self, **kw):
+                created.append(kw)
+                return kw["conversation_id"]
+
+            async def append_message(self, **kw):
+                pass
+
+        client = TestClient(_app(mock_orchestrator, fake_server,
+                                 conversation_repo=FakeRepo()))
+        client.post("/v1/customers/provision",
+                    json={"customer_id": "demo_acme", "demo": True})
+
+        assert len(created) >= 3
+        assert all(c["customer_id"] == "demo_acme" for c in created)

--- a/tests/unit/onboarding/conftest.py
+++ b/tests/unit/onboarding/conftest.py
@@ -1,0 +1,8 @@
+"""Shared fixtures for onboarding tests."""
+import pytest
+import fakeredis.aioredis
+
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis()

--- a/tests/unit/onboarding/test_demo_seed.py
+++ b/tests/unit/onboarding/test_demo_seed.py
@@ -26,10 +26,11 @@ class TestSettingsSeeding:
 
         raw = await fake_redis.get("settings:demo_acme")
         settings = json.loads(raw)
+        # Prove the seeder wrote *non-default* values. briefing.enabled
+        # defaults to True so asserting it proves nothing; these don't:
         assert settings["working_hours"]["start"] != "09:00" or \
-               settings["working_hours"]["timezone"] != "UTC"  # non-default
-        assert settings["briefing"]["enabled"] is True
-        assert settings["personality"]["tone"] == "friendly"
+               settings["working_hours"]["timezone"] != "UTC"
+        assert settings["personality"]["tone"] == "friendly"  # default: professional
 
     async def test_onboarding_marked_complete(self, fake_redis):
         await seed_demo_account(fake_redis, "demo_acme")

--- a/tests/unit/onboarding/test_demo_seed.py
+++ b/tests/unit/onboarding/test_demo_seed.py
@@ -1,0 +1,146 @@
+"""
+Demo mode seeding — populate a fresh account with realistic sample data
+so the dashboard has something to show in every section.
+
+Seeded in Redis (no Postgres dependency for the MVP demo path):
+  - settings:{customer_id}         — configured hours, briefing, tone
+  - onboarding:{customer_id}       — marked completed
+  - proactive:{customer_id}:notifications — sample briefing + alerts
+  - activity:{customer_id}:*       — message + delegation counts for today
+
+Conversation seeding into Postgres is optional and tested separately;
+here we validate the Redis half.
+"""
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src.onboarding.demo_seed import seed_demo_account
+from src.onboarding.state import OnboardingStateStore
+
+
+class TestSettingsSeeding:
+    async def test_seeds_configured_settings(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        raw = await fake_redis.get("settings:demo_acme")
+        settings = json.loads(raw)
+        assert settings["working_hours"]["start"] != "09:00" or \
+               settings["working_hours"]["timezone"] != "UTC"  # non-default
+        assert settings["briefing"]["enabled"] is True
+        assert settings["personality"]["tone"] == "friendly"
+
+    async def test_onboarding_marked_complete(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        store = OnboardingStateStore(fake_redis)
+        assert await store.is_complete("demo_acme")
+
+
+class TestNotificationSeeding:
+    async def test_seeds_multiple_notifications(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        raw = await fake_redis.hgetall("proactive:demo_acme:notifications")
+        assert len(raw) >= 3
+
+    async def test_notifications_have_required_fields(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        raw = await fake_redis.hgetall("proactive:demo_acme:notifications")
+        for v in raw.values():
+            n = json.loads(v)
+            assert n["id"]
+            assert n["status"] == "pending"
+            assert n["priority"] in ("LOW", "MEDIUM", "HIGH", "URGENT")
+            assert n["domain"]
+            assert n["title"]
+            assert n["message"]
+            assert n["created_at"]
+
+    async def test_notifications_cover_multiple_domains(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        raw = await fake_redis.hgetall("proactive:demo_acme:notifications")
+        domains = {json.loads(v)["domain"] for v in raw.values()}
+        assert len(domains) >= 2  # not all from one specialist
+
+
+class TestActivitySeeding:
+    async def test_seeds_message_counter(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        today = date.today().isoformat()
+        count = await fake_redis.get(f"activity:demo_acme:messages:{today}")
+        assert int(count) > 0
+
+    async def test_seeds_delegation_counters(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_acme")
+
+        today = date.today().isoformat()
+        # At least two domains have activity
+        domains_with_activity = 0
+        for domain in ("finance", "scheduling", "social_media", "workflows"):
+            v = await fake_redis.get(f"activity:demo_acme:delegation:{domain}:{today}")
+            if v and int(v) > 0:
+                domains_with_activity += 1
+        assert domains_with_activity >= 2
+
+
+class TestTenantIsolation:
+    async def test_demo_data_scoped_to_customer(self, fake_redis):
+        await seed_demo_account(fake_redis, "demo_alice")
+        await seed_demo_account(fake_redis, "demo_bob")
+
+        # Alice's notifications don't appear under Bob's key
+        alice_notifs = await fake_redis.hgetall("proactive:demo_alice:notifications")
+        bob_notifs = await fake_redis.hgetall("proactive:demo_bob:notifications")
+        assert alice_notifs and bob_notifs
+        # Settings are independent
+        alice_settings = await fake_redis.get("settings:demo_alice")
+        bob_settings = await fake_redis.get("settings:demo_bob")
+        assert alice_settings and bob_settings
+
+
+class TestConversationSeeding:
+    async def test_seeds_conversations_when_repo_provided(self, fake_redis):
+        """When a conversation repo is passed, seed sample exchanges."""
+        calls = []
+
+        class FakeRepo:
+            async def create_conversation(self, **kw):
+                calls.append(("conv", kw))
+                return kw.get("conversation_id") or "conv_1"
+
+            async def append_message(self, **kw):
+                calls.append(("msg", kw))
+
+        await seed_demo_account(fake_redis, "demo_acme", conversation_repo=FakeRepo())
+
+        convs = [c for c in calls if c[0] == "conv"]
+        msgs = [c for c in calls if c[0] == "msg"]
+        assert len(convs) >= 3
+        assert len(msgs) >= 6  # at least one user+assistant pair per conv
+        # All scoped to the demo customer
+        for _, kw in calls:
+            assert kw["customer_id"] == "demo_acme"
+
+    async def test_conversations_cover_specialist_domains(self, fake_redis):
+        domains = []
+
+        class FakeRepo:
+            async def create_conversation(self, **kw):
+                return kw.get("conversation_id") or "c"
+
+            async def append_message(self, **kw):
+                if kw.get("specialist_domain"):
+                    domains.append(kw["specialist_domain"])
+
+        await seed_demo_account(fake_redis, "demo_acme", conversation_repo=FakeRepo())
+
+        assert len(set(domains)) >= 2
+
+    async def test_no_repo_skips_conversations_silently(self, fake_redis):
+        # No exception when repo is None
+        await seed_demo_account(fake_redis, "demo_acme", conversation_repo=None)

--- a/tests/unit/onboarding/test_ea_integration.py
+++ b/tests/unit/onboarding/test_ea_integration.py
@@ -1,0 +1,164 @@
+"""
+EA ↔ onboarding integration.
+
+At the top of handle_customer_interaction, the EA checks onboarding
+state. If incomplete, the onboarding flow handles the turn instead of
+the normal LangGraph. If complete, the onboarding check is a single
+Redis GET and normal processing continues.
+
+Interrupt handling: if the customer sends a real task request
+mid-onboarding, the EA handles it normally, then prompts to resume.
+"""
+import json
+
+import pytest
+import fakeredis.aioredis
+from unittest.mock import AsyncMock, patch
+
+from src.onboarding.state import OnboardingStateStore, OnboardingStep
+
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def ea(fake_redis):
+    with patch("src.agents.executive_assistant.ExecutiveAssistantMemory") as MockMem, \
+         patch("src.agents.executive_assistant.WorkflowCreator"), \
+         patch("src.agents.executive_assistant.ChatOpenAI"):
+        from src.agents.executive_assistant import ExecutiveAssistant, BusinessContext
+
+        mem = MockMem.return_value
+        mem.get_business_context = AsyncMock(return_value=BusinessContext(
+            business_name="Test Co",
+        ))
+        mem.search_business_knowledge = AsyncMock(return_value=[])
+        mem.store_conversation_context = AsyncMock()
+        mem.get_conversation_context = AsyncMock(return_value={})
+        mem.store_business_context = AsyncMock()
+
+        instance = ExecutiveAssistant(customer_id="cust_onboard")
+        instance.llm = None
+        instance.settings_redis = fake_redis
+        yield instance
+
+
+class TestOnboardingRouting:
+    async def test_new_customer_gets_intro(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+
+        reply = await ea.handle_customer_interaction(
+            "hello", ConversationChannel.WHATSAPP
+        )
+
+        assert "Assistant" in reply  # default personality name
+        assert "business" in reply.lower()
+
+    async def test_completed_customer_skips_onboarding(self, ea, fake_redis):
+        """After completion, normal EA flow runs — onboarding never
+        re-introduces itself."""
+        from src.agents.executive_assistant import ConversationChannel
+
+        store = OnboardingStateStore(fake_redis)
+        await store.complete("cust_onboard")
+
+        reply = await ea.handle_customer_interaction(
+            "hello", ConversationChannel.WHATSAPP
+        )
+
+        # No re-introduction
+        assert "what kind of business" not in reply.lower()
+
+    async def test_onboarding_progresses_across_turns(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+
+        await ea.handle_customer_interaction("hi", ConversationChannel.WHATSAPP)
+        await ea.handle_customer_interaction(
+            "consulting firm", ConversationChannel.WHATSAPP
+        )
+
+        store = OnboardingStateStore(fake_redis)
+        state = await store.get("cust_onboard")
+        assert state.step == OnboardingStep.PREFERENCES
+        assert "consulting" in state.collected["business_context"]
+
+    async def test_full_onboarding_completes(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+        ch = ConversationChannel.WHATSAPP
+
+        await ea.handle_customer_interaction("hi", ch)
+        await ea.handle_customer_interaction("restaurant", ch)
+        await ea.handle_customer_interaction("9 to 5 eastern", ch)
+        await ea.handle_customer_interaction("yes", ch)
+
+        store = OnboardingStateStore(fake_redis)
+        assert await store.is_complete("cust_onboard")
+
+        # Settings were written
+        raw = await fake_redis.get("settings:cust_onboard")
+        settings = json.loads(raw)
+        assert settings["working_hours"]["start"] == "09:00"
+
+    async def test_no_settings_redis_skips_onboarding(self, ea):
+        """Legacy construction path — no settings_redis → can't check
+        state → skip onboarding entirely rather than crash."""
+        from src.agents.executive_assistant import ConversationChannel
+
+        ea.settings_redis = None
+        reply = await ea.handle_customer_interaction(
+            "hello", ConversationChannel.WHATSAPP
+        )
+        # Doesn't crash, doesn't run onboarding
+        assert "what kind of business" not in reply.lower()
+
+
+class TestInterruptHandling:
+    async def test_real_request_interrupts_onboarding(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+        ch = ConversationChannel.WHATSAPP
+
+        await ea.handle_customer_interaction("hi", ch)  # intro
+
+        # Customer interrupts with a real request
+        reply = await ea.handle_customer_interaction(
+            "actually can you schedule a meeting for tomorrow at 3pm?", ch
+        )
+
+        # EA handled the real request (not asking about business type)
+        assert "working hours" not in reply.lower()
+        # And onboarding state didn't advance past where it was
+        store = OnboardingStateStore(fake_redis)
+        state = await store.get("cust_onboard")
+        # Still at business_context (the step after intro) OR completed
+        # if EA decided to skip remaining steps
+        assert state.step in (OnboardingStep.BUSINESS_CONTEXT, OnboardingStep.DONE)
+
+    async def test_interrupt_mentions_returning_to_setup(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+        ch = ConversationChannel.WHATSAPP
+
+        await ea.handle_customer_interaction("hi", ch)
+        reply = await ea.handle_customer_interaction(
+            "actually schedule a meeting tomorrow at 2pm", ch
+        )
+
+        # Reply references returning to setup or finishing later
+        lowered = reply.lower()
+        assert any(w in lowered for w in ["setup", "onboarding", "later", "back to"])
+
+
+class TestPersonalityAppliedDuringOnboarding:
+    async def test_configured_name_used_in_intro(self, ea, fake_redis):
+        from src.agents.executive_assistant import ConversationChannel
+
+        await fake_redis.set("settings:cust_onboard", json.dumps({
+            "personality": {"name": "Aria", "tone": "friendly", "language": "en"}
+        }))
+
+        reply = await ea.handle_customer_interaction(
+            "hello", ConversationChannel.WHATSAPP
+        )
+
+        assert "Aria" in reply

--- a/tests/unit/onboarding/test_flow.py
+++ b/tests/unit/onboarding/test_flow.py
@@ -1,0 +1,227 @@
+"""
+Onboarding flow — the 5-step guided conversation.
+
+The flow is stateful across turns via OnboardingStateStore. Each call
+to ``handle()`` consumes one customer message and returns one EA reply.
+The flow drives the conversation; the customer responds.
+
+Personality (name, tone) comes from the same settings dict the EA uses
+so onboarding feels like the rest of the product.
+"""
+import json
+
+import pytest
+
+from src.onboarding.flow import OnboardingFlow
+from src.onboarding.state import OnboardingStateStore, OnboardingStep
+
+
+@pytest.fixture
+def store(fake_redis):
+    return OnboardingStateStore(fake_redis)
+
+
+@pytest.fixture
+def flow(store, fake_redis):
+    return OnboardingFlow(
+        state_store=store,
+        settings_redis=fake_redis,
+        personality={"name": "Sarah", "tone": "friendly", "language": "en"},
+    )
+
+
+class TestIntroduction:
+    async def test_first_message_introduces_ea_by_name(self, flow, store):
+        reply = await flow.handle("cust_a", "hello")
+
+        assert "Sarah" in reply
+        state = await store.get("cust_a")
+        assert state.step == OnboardingStep.BUSINESS_CONTEXT
+
+    async def test_intro_mentions_capabilities(self, flow):
+        reply = await flow.handle("cust_a", "hi")
+
+        # Brief, not a wall of text
+        assert len(reply) < 500
+        # Mentions core specialist domains
+        lowered = reply.lower()
+        assert any(w in lowered for w in ["schedul", "calendar"])
+        assert any(w in lowered for w in ["financ", "expense"])
+
+    async def test_intro_asks_about_business(self, flow):
+        reply = await flow.handle("cust_a", "hey")
+        assert "?" in reply  # ends with a question
+
+
+class TestBusinessContext:
+    async def test_stores_business_answer(self, flow, store):
+        await flow.handle("cust_a", "hi")  # intro → asks business
+
+        await flow.handle("cust_a", "I run a small Italian restaurant")
+
+        state = await store.get("cust_a")
+        assert "restaurant" in state.collected["business_context"].lower()
+        assert state.step == OnboardingStep.PREFERENCES
+
+    async def test_free_text_accepted(self, flow, store):
+        """No forced categories — whatever they say gets stored."""
+        await flow.handle("cust_a", "hi")
+
+        await flow.handle("cust_a", "uh, hard to explain, bit of everything")
+
+        state = await store.get("cust_a")
+        assert state.collected["business_context"]  # non-empty
+        assert state.step == OnboardingStep.PREFERENCES
+
+    async def test_asks_for_working_hours_next(self, flow):
+        await flow.handle("cust_a", "hi")
+
+        reply = await flow.handle("cust_a", "consulting firm")
+
+        lowered = reply.lower()
+        assert any(w in lowered for w in ["hours", "timezone", "work"])
+
+
+class TestPreferences:
+    async def test_parses_natural_language_hours(self, flow, fake_redis):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "consulting")
+
+        await flow.handle("cust_a", "I work 9 to 5 Eastern")
+
+        raw = await fake_redis.get("settings:cust_a")
+        settings = json.loads(raw)
+        assert settings["working_hours"]["start"] == "09:00"
+        assert settings["working_hours"]["end"] == "17:00"
+        assert "Eastern" in settings["working_hours"]["timezone"] or \
+               "New_York" in settings["working_hours"]["timezone"]
+
+    async def test_parses_24h_format(self, flow, fake_redis):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "tech startup")
+
+        await flow.handle("cust_a", "08:30 to 18:00 UTC")
+
+        settings = json.loads(await fake_redis.get("settings:cust_a"))
+        assert settings["working_hours"]["start"] == "08:30"
+        assert settings["working_hours"]["end"] == "18:00"
+
+    async def test_unclear_answer_uses_defaults(self, flow, fake_redis):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "retail")
+
+        reply = await flow.handle("cust_a", "whenever really")
+
+        settings = json.loads(await fake_redis.get("settings:cust_a"))
+        assert settings["working_hours"]["start"] == "09:00"  # default
+        assert "dashboard" in reply.lower()  # tells them they can change it
+
+    async def test_advances_to_quick_win(self, flow, store):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "law firm")
+
+        await flow.handle("cust_a", "9 to 6")
+
+        state = await store.get("cust_a")
+        assert state.step == OnboardingStep.QUICK_WIN
+
+
+class TestQuickWin:
+    async def _run_to_quick_win(self, flow, business):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", business)
+        return await flow.handle("cust_a", "9 to 5")
+
+    async def test_restaurant_gets_reservation_suggestion(self, flow):
+        reply = await self._run_to_quick_win(flow, "I run a restaurant")
+        assert "reservation" in reply.lower()
+
+    async def test_consulting_gets_briefing_suggestion(self, flow):
+        reply = await self._run_to_quick_win(flow, "consulting firm")
+        assert "briefing" in reply.lower() or "meeting" in reply.lower()
+
+    async def test_unknown_business_gets_generic_briefing(self, flow):
+        reply = await self._run_to_quick_win(flow, "something unusual")
+        assert "briefing" in reply.lower() or "morning" in reply.lower()
+
+    async def test_accepting_quick_win_enables_briefing(self, flow, fake_redis):
+        await self._run_to_quick_win(flow, "consulting")
+
+        await flow.handle("cust_a", "yes please")
+
+        settings = json.loads(await fake_redis.get("settings:cust_a"))
+        assert settings["briefing"]["enabled"] is True
+
+    async def test_declining_quick_win_moves_on(self, flow, store):
+        await self._run_to_quick_win(flow, "retail")
+
+        reply = await flow.handle("cust_a", "not now")
+
+        state = await store.get("cust_a")
+        assert state.status == "completed"
+        # Acknowledges gracefully
+        assert any(w in reply.lower() for w in ["no problem", "anytime", "later"])
+
+
+class TestCompletion:
+    async def test_full_flow_completes(self, flow, store):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "bakery")
+        await flow.handle("cust_a", "6am to 2pm")
+        await flow.handle("cust_a", "sure")
+
+        state = await store.get("cust_a")
+        assert state.status == "completed"
+
+    async def test_completion_mentions_dashboard(self, flow):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "bakery")
+        await flow.handle("cust_a", "6am to 2pm")
+
+        reply = await flow.handle("cust_a", "yes")
+
+        assert "dashboard" in reply.lower()
+
+    async def test_completed_flow_returns_none(self, flow, store):
+        """Once complete, the flow hands back control — returns None to
+        signal 'not my turn anymore, route normally'."""
+        await store.complete("cust_a")
+
+        result = await flow.handle("cust_a", "schedule a meeting")
+
+        assert result is None
+
+
+class TestResume:
+    async def test_resumes_at_correct_step(self, flow, store, fake_redis):
+        await flow.handle("cust_a", "hi")
+        await flow.handle("cust_a", "restaurant")
+        # Customer drops off here — state persisted in Redis
+
+        # New flow instance, same Redis
+        fresh_flow = OnboardingFlow(
+            state_store=OnboardingStateStore(fake_redis),
+            settings_redis=fake_redis,
+            personality={"name": "Sarah", "tone": "friendly", "language": "en"},
+        )
+        reply = await fresh_flow.handle("cust_a", "10 to 6 Pacific")
+
+        # Should process as PREFERENCES answer, not restart intro
+        assert "Sarah" not in reply  # no re-introduction
+        state = await store.get("cust_a")
+        assert state.step == OnboardingStep.QUICK_WIN
+
+
+class TestInterrupt:
+    async def test_detects_real_request(self, flow):
+        await flow.handle("cust_a", "hi")
+
+        is_interrupt = flow.looks_like_real_request(
+            "actually can you schedule a meeting for tomorrow at 3pm?"
+        )
+        assert is_interrupt
+
+    async def test_onboarding_answer_not_interrupt(self, flow):
+        assert not flow.looks_like_real_request("I run a restaurant")
+        assert not flow.looks_like_real_request("9 to 5 eastern")
+        assert not flow.looks_like_real_request("yes please")

--- a/tests/unit/onboarding/test_flow.py
+++ b/tests/unit/onboarding/test_flow.py
@@ -145,6 +145,12 @@ class TestQuickWin:
         assert "briefing" in reply.lower() or "morning" in reply.lower()
 
     async def test_accepting_quick_win_enables_briefing(self, flow, fake_redis):
+        """BriefingSettings.enabled defaults to True — pre-seed it False
+        so the test actually proves the flow *flipped* it, not that the
+        default survived untouched."""
+        await fake_redis.set("settings:cust_a", json.dumps({
+            "briefing": {"enabled": False},
+        }))
         await self._run_to_quick_win(flow, "consulting")
 
         await flow.handle("cust_a", "yes please")

--- a/tests/unit/onboarding/test_flow.py
+++ b/tests/unit/onboarding/test_flow.py
@@ -1,5 +1,5 @@
 """
-Onboarding flow — the 5-step guided conversation.
+Onboarding flow — 4-step guided conversation.
 
 The flow is stateful across turns via OnboardingStateStore. Each call
 to ``handle()`` consumes one customer message and returns one EA reply.

--- a/tests/unit/onboarding/test_state.py
+++ b/tests/unit/onboarding/test_state.py
@@ -25,12 +25,17 @@ class TestInitialState:
         assert state.status == "not_started"
         assert state.step == OnboardingStep.INTRO
 
-    async def test_initialize_sets_not_started(self, fake_redis):
+    async def test_initialize_writes_key(self, fake_redis):
+        """Unseen customers *default* to not_started via get(), so the
+        only way to prove initialize() did work is to check the key
+        actually landed in Redis."""
         store = OnboardingStateStore(fake_redis)
 
+        assert await fake_redis.get("onboarding:cust_fresh") is None
         await store.initialize("cust_fresh")
-        state = await store.get("cust_fresh")
+        assert await fake_redis.get("onboarding:cust_fresh") is not None
 
+        state = await store.get("cust_fresh")
         assert state.status == "not_started"
         assert state.step == OnboardingStep.INTRO
         assert state.collected == {}
@@ -134,12 +139,26 @@ class TestTenantIsolation:
         assert parsed["step"] == OnboardingStep.BUSINESS_CONTEXT.value
 
 
-class TestCompletionNeverRepeats:
+class TestInitializeIdempotence:
     async def test_completed_stays_completed_after_initialize(self, fake_redis):
         """Re-provisioning a completed customer must not reset onboarding."""
         store = OnboardingStateStore(fake_redis)
         await store.complete("cust_done")
 
-        await store.initialize("cust_done")  # idempotent no-op
+        await store.initialize("cust_done")
 
         assert await store.is_complete("cust_done")
+
+    async def test_in_progress_not_reset_by_initialize(self, fake_redis):
+        """Customer mid-flow, ops re-runs provisioning — must not lose
+        their progress."""
+        store = OnboardingStateStore(fake_redis)
+        await store.advance("cust_mid", OnboardingStep.PREFERENCES,
+                            collected={"business_context": "retail"})
+
+        await store.initialize("cust_mid")
+
+        state = await store.get("cust_mid")
+        assert state.status == "in_progress"
+        assert state.step == OnboardingStep.PREFERENCES
+        assert state.collected == {"business_context": "retail"}

--- a/tests/unit/onboarding/test_state.py
+++ b/tests/unit/onboarding/test_state.py
@@ -1,0 +1,145 @@
+"""
+Onboarding state store — Redis-backed per-customer wizard progress.
+
+Key: onboarding:{customer_id}
+State machine: not_started → in_progress → completed
+Step tracking so a dropped-off customer resumes where they left off.
+"""
+import json
+
+import pytest
+
+from src.onboarding.state import (
+    OnboardingState,
+    OnboardingStateStore,
+    OnboardingStep,
+)
+
+
+class TestInitialState:
+    async def test_unseen_customer_is_not_started(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+
+        state = await store.get("cust_new")
+
+        assert state.status == "not_started"
+        assert state.step == OnboardingStep.INTRO
+
+    async def test_initialize_sets_not_started(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+
+        await store.initialize("cust_fresh")
+        state = await store.get("cust_fresh")
+
+        assert state.status == "not_started"
+        assert state.step == OnboardingStep.INTRO
+        assert state.collected == {}
+
+
+class TestProgression:
+    async def test_advance_moves_to_next_step(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+        await store.initialize("cust_a")
+
+        await store.advance("cust_a", OnboardingStep.BUSINESS_CONTEXT)
+        state = await store.get("cust_a")
+
+        assert state.status == "in_progress"
+        assert state.step == OnboardingStep.BUSINESS_CONTEXT
+
+    async def test_advance_stores_collected_data(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+        await store.initialize("cust_a")
+
+        await store.advance(
+            "cust_a",
+            OnboardingStep.PREFERENCES,
+            collected={"business_context": "small jewelry shop"},
+        )
+        state = await store.get("cust_a")
+
+        assert state.collected["business_context"] == "small jewelry shop"
+
+    async def test_advance_merges_collected_data(self, fake_redis):
+        """Each step adds to collected, not replaces."""
+        store = OnboardingStateStore(fake_redis)
+        await store.initialize("cust_a")
+
+        await store.advance("cust_a", OnboardingStep.BUSINESS_CONTEXT,
+                            collected={"business_context": "restaurant"})
+        await store.advance("cust_a", OnboardingStep.PREFERENCES,
+                            collected={"timezone": "America/New_York"})
+
+        state = await store.get("cust_a")
+        assert state.collected["business_context"] == "restaurant"
+        assert state.collected["timezone"] == "America/New_York"
+
+    async def test_complete_marks_done(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+        await store.initialize("cust_a")
+
+        await store.complete("cust_a")
+        state = await store.get("cust_a")
+
+        assert state.status == "completed"
+
+    async def test_is_complete_shorthand(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+
+        assert not await store.is_complete("cust_a")
+        await store.complete("cust_a")
+        assert await store.is_complete("cust_a")
+
+
+class TestResume:
+    async def test_resumes_at_stored_step(self, fake_redis):
+        """Customer drops off mid-flow, comes back — state persists."""
+        store = OnboardingStateStore(fake_redis)
+        await store.initialize("cust_resume")
+        await store.advance("cust_resume", OnboardingStep.PREFERENCES,
+                            collected={"business_context": "consulting"})
+
+        # New store instance — simulates process restart
+        fresh_store = OnboardingStateStore(fake_redis)
+        state = await fresh_store.get("cust_resume")
+
+        assert state.status == "in_progress"
+        assert state.step == OnboardingStep.PREFERENCES
+        assert state.collected["business_context"] == "consulting"
+
+
+class TestTenantIsolation:
+    async def test_customers_have_independent_state(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+
+        await store.advance("cust_alice", OnboardingStep.QUICK_WIN)
+        await store.complete("cust_bob")
+
+        alice = await store.get("cust_alice")
+        bob = await store.get("cust_bob")
+        carol = await store.get("cust_carol")
+
+        assert alice.status == "in_progress"
+        assert alice.step == OnboardingStep.QUICK_WIN
+        assert bob.status == "completed"
+        assert carol.status == "not_started"
+
+    async def test_redis_key_is_customer_scoped(self, fake_redis):
+        store = OnboardingStateStore(fake_redis)
+        await store.advance("cust_xyz", OnboardingStep.BUSINESS_CONTEXT)
+
+        raw = await fake_redis.get("onboarding:cust_xyz")
+        assert raw is not None
+        parsed = json.loads(raw)
+        assert parsed["step"] == OnboardingStep.BUSINESS_CONTEXT.value
+
+
+class TestCompletionNeverRepeats:
+    async def test_completed_stays_completed_after_initialize(self, fake_redis):
+        """Re-provisioning a completed customer must not reset onboarding."""
+        store = OnboardingStateStore(fake_redis)
+        await store.complete("cust_done")
+
+        await store.initialize("cust_done")  # idempotent no-op
+
+        assert await store.is_complete("cust_done")


### PR DESCRIPTION
## Summary

Conversational onboarding wizard that runs before normal EA routing for new customers, plus demo-mode provisioning that pre-populates a fresh account with realistic sample data.

### Onboarding flow
- 4-step guided conversation: intro → business context → working-hours preferences → quick-win offer
- Redis-backed state at `onboarding:{customer_id}` — survives process restarts, customers resume mid-flow
- NL parsing for working hours ("9 to 5 Eastern" → `09:00`–`17:00`, `America/New_York`)
- Business-type-aware quick-win suggestions (restaurant → reservation summary, consultancy → morning briefing)
- **Interrupt handling**: mid-onboarding task requests ("actually schedule a call") route to the normal graph, flow state pauses and resumes on the next non-task message
- Gated in `ExecutiveAssistant._maybe_onboard()` — one Redis GET per turn, fast-path exit once complete

### Provisioning enhancements
`POST /v1/customers/provision` now seeds:
- Default `Settings` at `settings:{customer_id}`
- Onboarding state initialized to `not_started`
- Dashboard auth secret at `auth:{customer_id}:secret`, returned in response body

Seeding is best-effort — Redis failure logs a warning but the customer still gets their JWT.

### Demo mode
`demo: true` on the provision request runs `seed_demo_account()` instead:
- Settings with friendly tone, configured hours, EA named "Sarah"
- Onboarding marked `completed` (wizard skipped)
- 3 sample notifications (briefing, finance anomaly, workflow status)
- Activity counters for today's dashboard card
- Sample conversations across 4 specialist domains (if a Postgres repo is wired)

## Commits

12 commits, strict TDD (test → impl pairs), plus two audit commits:

| | |
|---|---|
| test/feat | State store — tenant-isolated wizard progress |
| test/feat | Flow engine — 4-step wizard, NL parsing, interrupts |
| test/feat | EA integration — routing gate, interrupt handling |
| test/feat | Demo seeder — settings, notifications, activity, conversations |
| test/feat | Provisioning — auto-seed defaults, auth secret, demo mode |
| test | Audit — fixed happy-green `briefing.enabled` assertions (default is `True`) |
| docs | Audit — step count, package `__init__`, DEVELOPMENT.md |

## Test plan

- [x] 61 unit tests pass (`tests/unit/onboarding/` + `tests/unit/api/test_provisioning_seed.py`)
- [x] Happy-green audit: `briefing.enabled` assertions now pre-seed `False` or rely on non-default fields
- [x] Idempotence: `initialize()` verified by key presence, not `get()` default; in-progress state survives re-provision
- [ ] Manual: provision with `demo: true`, confirm dashboard shows populated cards
- [ ] Manual: fresh provision, send first WhatsApp message, walk the 4-step flow
- [ ] Manual: mid-flow, send "schedule a meeting with X" — confirm interrupt + resume note

## Notes

- 15 pre-existing failures on `main` in `tests/unit/proactive/` (time-sensitive `quiet_hours` tests) — unrelated, confirmed broken on clean main
- `docs/README.md` calls LAUNCH-Bot "onboarding system design" — that's infra provisioning, not this. Disambiguated in `src/onboarding/__init__.py` rather than touching the globally-stale doc index

🤖 Generated with [Claude Code](https://claude.com/claude-code)