### PR TITLE
feat: cross-domain context and specialist quality enhancements

### DIFF
--- a/src/agents/base/specialist.py
+++ b/src/agents/base/specialist.py
@@ -61,6 +61,8 @@ class SpecialistTask:
     domain_memories are pre-fetched by the EA — the specialist never gets
     direct memory-client access. prior_turns carries clarification Q&A on
     multi-turn delegations without exposing the full conversation.
+    interaction_context is the cross-domain snapshot assembled by
+    ContextAssembler — None when the assembler is not wired.
     """
     description: str
     customer_id: str

--- a/src/agents/base/specialist.py
+++ b/src/agents/base/specialist.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from src.agents.context import InteractionContext
     from src.agents.executive_assistant import BusinessContext
     from src.proactive.triggers import ProactiveTrigger
 
@@ -66,6 +67,7 @@ class SpecialistTask:
     business_context: "BusinessContext"
     domain_memories: List[Dict[str, Any]]
     prior_turns: List[Dict[str, str]] = field(default_factory=list)
+    interaction_context: Optional["InteractionContext"] = None
 
 
 @dataclass

--- a/src/agents/context.py
+++ b/src/agents/context.py
@@ -1,0 +1,235 @@
+"""
+Shared interaction context — assembled once per interaction, passed read-only
+to the specialist that handles the delegation.
+
+The ContextAssembler aggregates lightweight snapshots from each domain
+(calendar, finance, workflows, notifications) with per-source timeouts
+so a slow or broken domain never blocks the customer's response.
+
+Lazy loading: if the EA knows the message is about scheduling, it tells
+the assembler ``relevant_domains={"scheduling"}`` and the finance/workflow
+sources are skipped entirely. If the message is ambiguous, all domains
+produce summaries.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.proactive.state import ProactiveStateStore
+
+logger = logging.getLogger(__name__)
+
+
+# --- Read-only snapshot types -----------------------------------------------
+
+@dataclass(frozen=True)
+class CalendarSnapshot:
+    events_next_24h: List[Dict[str, Any]]
+    has_conflicts: bool = False
+
+
+@dataclass(frozen=True)
+class FinanceSnapshot:
+    transaction_baseline: Optional[float] = None
+    recent_expense_total: Optional[float] = None
+    top_category: Optional[str] = None
+    budget_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkflowSnapshot:
+    active_count: int = 0
+    workflow_names: List[str] = field(default_factory=list)
+    recent_failures: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class CustomerPreferences:
+    tone: str = "professional"
+    working_hours: Optional[Dict[str, str]] = None
+    business_type: str = ""
+    language: str = "en"
+
+
+@dataclass
+class DelegationRecord:
+    domain: str = ""
+    status: str = ""
+    timestamp: str = ""
+
+
+@dataclass
+class InteractionContext:
+    """Read-only context assembled once per interaction."""
+    recent_conversation_summary: Optional[str] = None
+    calendar_snapshot: Optional[CalendarSnapshot] = None
+    finance_snapshot: Optional[FinanceSnapshot] = None
+    workflow_snapshot: Optional[WorkflowSnapshot] = None
+    pending_notifications: List[Dict[str, Any]] = field(default_factory=list)
+    customer_preferences: CustomerPreferences = field(default_factory=CustomerPreferences)
+    delegation_history: List[DelegationRecord] = field(default_factory=list)
+
+
+# --- Domain relevance -------------------------------------------------------
+
+_DOMAIN_MAP: Dict[str, Set[str]] = {
+    "scheduling": {"scheduling"},
+    "finance": {"finance"},
+    "workflows": {"workflows"},
+    "social_media": {"social_media"},
+}
+
+
+# --- Assembler --------------------------------------------------------------
+
+class ContextAssembler:
+    """Assembles InteractionContext from domain sources with timeouts."""
+
+    def __init__(
+        self,
+        *,
+        proactive_store: "ProactiveStateStore",
+        settings_redis,
+        source_timeout: float = 2.0,
+    ):
+        self._proactive = proactive_store
+        self._settings_redis = settings_redis
+        self._source_timeout = source_timeout
+
+    async def assemble(
+        self,
+        customer_id: str,
+        *,
+        relevant_domains: Set[str],
+        calendar_client=None,
+        workflow_store=None,
+        conversation_summary: Optional[str] = None,
+        delegation_history: Optional[List[DelegationRecord]] = None,
+    ) -> InteractionContext:
+        """Build context. Each domain source respects timeout independently."""
+        fetch_all = len(relevant_domains) == 0
+
+        # Launch all relevant fetches concurrently.
+        cal_task = None
+        fin_task = None
+        wf_task = None
+
+        if (fetch_all or "scheduling" in relevant_domains) and calendar_client is not None:
+            cal_task = asyncio.ensure_future(
+                self._fetch_calendar(customer_id, calendar_client)
+            )
+
+        if fetch_all or "finance" in relevant_domains:
+            fin_task = asyncio.ensure_future(
+                self._fetch_finance(customer_id)
+            )
+
+        if (fetch_all or "workflows" in relevant_domains) and workflow_store is not None:
+            wf_task = asyncio.ensure_future(
+                self._fetch_workflows(customer_id, workflow_store)
+            )
+
+        notif_task = asyncio.ensure_future(self._fetch_notifications(customer_id))
+        prefs_task = asyncio.ensure_future(self._fetch_preferences(customer_id))
+
+        # Await with timeouts — each source independent.
+        calendar_snapshot = await self._guarded(cal_task, "calendar")
+        finance_snapshot = await self._guarded(fin_task, "finance")
+        workflow_snapshot = await self._guarded(wf_task, "workflows")
+        notifications = await self._guarded(notif_task, "notifications") or []
+        preferences = await self._guarded(prefs_task, "preferences") or CustomerPreferences()
+
+        return InteractionContext(
+            recent_conversation_summary=conversation_summary,
+            calendar_snapshot=calendar_snapshot,
+            finance_snapshot=finance_snapshot,
+            workflow_snapshot=workflow_snapshot,
+            pending_notifications=notifications,
+            customer_preferences=preferences,
+            delegation_history=delegation_history or [],
+        )
+
+    async def _guarded(self, task, label: str):
+        """Await a task with timeout + error guard. Returns None on failure."""
+        if task is None:
+            return None
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), timeout=self._source_timeout)
+        except asyncio.TimeoutError:
+            logger.warning(f"Context source '{label}' timed out after {self._source_timeout}s")
+            task.cancel()
+            return None
+        except Exception as e:
+            logger.warning(f"Context source '{label}' failed: {e}")
+            return None
+
+    # --- Per-domain fetch methods -------------------------------------------
+
+    async def _fetch_calendar(self, customer_id: str, calendar_client) -> CalendarSnapshot:
+        now = datetime.now(timezone.utc)
+        end = now + timedelta(hours=24)
+        events = await calendar_client.list_events(now, end)
+
+        event_dicts = []
+        for e in events:
+            event_dicts.append({
+                "id": getattr(e, "id", ""),
+                "title": getattr(e, "title", ""),
+                "start": e.start.isoformat() if hasattr(e.start, "isoformat") else str(e.start),
+                "end": e.end.isoformat() if hasattr(e.end, "isoformat") else str(e.end),
+            })
+
+        # Simple conflict check: any overlapping events in the next 24h
+        has_conflicts = False
+        sorted_events = sorted(events, key=lambda ev: ev.start)
+        for i in range(len(sorted_events) - 1):
+            if sorted_events[i].end > sorted_events[i + 1].start:
+                has_conflicts = True
+                break
+
+        return CalendarSnapshot(
+            events_next_24h=event_dicts,
+            has_conflicts=has_conflicts,
+        )
+
+    async def _fetch_finance(self, customer_id: str) -> FinanceSnapshot:
+        baseline = await self._proactive.get_transaction_baseline(customer_id)
+        return FinanceSnapshot(
+            transaction_baseline=baseline,
+        )
+
+    async def _fetch_workflows(self, customer_id: str, workflow_store) -> WorkflowSnapshot:
+        workflows = await workflow_store.list_workflows(customer_id)
+        active = [w for w in workflows if w.get("status") == "active"]
+        return WorkflowSnapshot(
+            active_count=len(active),
+            workflow_names=[w["name"] for w in active],
+            recent_failures=[w for w in workflows if w.get("status") == "error"],
+        )
+
+    async def _fetch_notifications(self, customer_id: str) -> List[Dict[str, Any]]:
+        now = datetime.now(timezone.utc)
+        return await self._proactive.list_pending_notifications(customer_id, now=now)
+
+    async def _fetch_preferences(self, customer_id: str) -> CustomerPreferences:
+        prefs = CustomerPreferences()
+        try:
+            raw = await self._settings_redis.get(f"settings:{customer_id}")
+            if not raw:
+                return prefs
+            data = json.loads(raw if isinstance(raw, str) else raw.decode())
+            personality = data.get("personality") or {}
+            prefs.tone = personality.get("tone", prefs.tone)
+            prefs.language = personality.get("language", prefs.language)
+            wh = data.get("working_hours")
+            if wh:
+                prefs.working_hours = wh
+        except Exception as e:
+            logger.warning(f"Preferences fetch failed, using defaults: {e}")
+        return prefs

--- a/src/agents/context.py
+++ b/src/agents/context.py
@@ -55,6 +55,9 @@ class CustomerPreferences:
     working_hours: Optional[Dict[str, str]] = None
     business_type: str = ""
     language: str = "en"
+    preferred_meeting_duration: Optional[int] = None  # minutes
+    preferred_hours: List[int] = field(default_factory=list)
+    buffer_minutes: int = 0
 
 
 @dataclass

--- a/src/agents/context.py
+++ b/src/agents/context.py
@@ -30,12 +30,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CalendarSnapshot:
+    """Next-24h calendar view: events list and conflict flag."""
     events_next_24h: List[Dict[str, Any]]
     has_conflicts: bool = False
 
 
 @dataclass(frozen=True)
 class FinanceSnapshot:
+    """Spending baseline and budget status for pattern-awareness checks."""
     transaction_baseline: Optional[float] = None
     recent_expense_total: Optional[float] = None
     top_category: Optional[str] = None
@@ -44,6 +46,7 @@ class FinanceSnapshot:
 
 @dataclass(frozen=True)
 class WorkflowSnapshot:
+    """Active automation count, names, and recent failures."""
     active_count: int = 0
     workflow_names: List[str] = field(default_factory=list)
     recent_failures: List[Dict[str, Any]] = field(default_factory=list)
@@ -51,6 +54,7 @@ class WorkflowSnapshot:
 
 @dataclass
 class CustomerPreferences:
+    """Customer settings loaded from Redis each interaction. Safe defaults — missing keys never break specialists."""
     tone: str = "professional"
     working_hours: Optional[Dict[str, str]] = None
     business_type: str = ""
@@ -62,6 +66,7 @@ class CustomerPreferences:
 
 @dataclass
 class DelegationRecord:
+    """One entry in the delegation log passed to specialists for continuity."""
     domain: str = ""
     status: str = ""
     timestamp: str = ""
@@ -175,6 +180,7 @@ class ContextAssembler:
     # --- Per-domain fetch methods -------------------------------------------
 
     async def _fetch_calendar(self, customer_id: str, calendar_client) -> CalendarSnapshot:
+        """Pull next-24h events and detect time overlaps."""
         now = datetime.now(timezone.utc)
         end = now + timedelta(hours=24)
         events = await calendar_client.list_events(now, end)
@@ -202,12 +208,14 @@ class ContextAssembler:
         )
 
     async def _fetch_finance(self, customer_id: str) -> FinanceSnapshot:
+        """Pull running transaction baseline from proactive state."""
         baseline = await self._proactive.get_transaction_baseline(customer_id)
         return FinanceSnapshot(
             transaction_baseline=baseline,
         )
 
     async def _fetch_workflows(self, customer_id: str, workflow_store) -> WorkflowSnapshot:
+        """Pull active/errored workflow list from the workflow store."""
         workflows = await workflow_store.list_workflows(customer_id)
         active = [w for w in workflows if w.get("status") == "active"]
         return WorkflowSnapshot(
@@ -217,10 +225,12 @@ class ContextAssembler:
         )
 
     async def _fetch_notifications(self, customer_id: str) -> List[Dict[str, Any]]:
+        """Pull pending un-snoozed notifications."""
         now = datetime.now(timezone.utc)
         return await self._proactive.list_pending_notifications(customer_id, now=now)
 
     async def _fetch_preferences(self, customer_id: str) -> CustomerPreferences:
+        """Load tone/language/working-hours from settings Redis; fall back to defaults."""
         prefs = CustomerPreferences()
         try:
             raw = await self._settings_redis.get(f"settings:{customer_id}")

--- a/src/agents/executive_assistant.py
+++ b/src/agents/executive_assistant.py
@@ -1,6 +1,12 @@
 """
-AI Agency Platform - Enhanced Executive Assistant Agent with AI/ML Memory Integration
-Sophisticated LangGraph conversation management with advanced business learning capabilities
+Executive Assistant — LangGraph orchestrator with specialist delegation.
+
+Routes customer messages through intent classification, delegates operational
+tasks to domain specialists (finance, scheduling, workflows, social media),
+and retains strategic/advisory questions. Personality-aware: tone and language
+adapt per customer via settings Redis. Cross-domain context assembly feeds
+specialists a read-only InteractionContext so they can reference calendar,
+finance, and workflow state without direct access.
 """
 
 import asyncio
@@ -614,16 +620,12 @@ class WorkflowCreator:
             return {"success": False, "error": str(e)}
 
 class ExecutiveAssistant:
-    """
-    Enhanced Executive Assistant with sophisticated LangGraph conversation management
-    
-    Features:
-    - Advanced intent classification with confidence scoring
-    - Multi-turn conversation state tracking
-    - Conditional conversation routing
-    - Template-first workflow creation
-    - Comprehensive business context learning
-    - Intelligent conversation branching
+    """LangGraph-based EA that orchestrates specialist delegation.
+
+    Owns the conversation graph, personality loading, context assembly, and
+    delegation lifecycle. Specialists receive a SpecialistTask with pre-assembled
+    InteractionContext; the EA merges their result into the response, applying
+    tone-aware synthesis.
     """
     
     def __init__(self, customer_id: str, mcp_server_url: str = None):

--- a/src/agents/executive_assistant.py
+++ b/src/agents/executive_assistant.py
@@ -675,6 +675,11 @@ class ExecutiveAssistant:
         # conversation intelligence (topic tagging, specialist metrics).
         self.delegation_recorder = None
 
+        # Optional context assembler — wired by create_default_app.
+        # When present, builds InteractionContext (cross-domain snapshots)
+        # for each delegation. Same injection pattern as audit_logger.
+        self._context_assembler = None
+
         # In-memory conversation history. Populated by handle_customer_interaction,
         # lost on LRU eviction from EARegistry — acceptable for now.
         self._conversation_histories: dict[str, list[dict]] = {}
@@ -1452,12 +1457,25 @@ The key difference: automation tools give you software to configure. I give you 
             logger.warning(f"Memory search failed during delegation, proceeding without: {e}")
             domain_memories = []
 
+        # Assemble cross-domain context if an assembler is wired.
+        # Best-effort: failure → None, delegation proceeds without context.
+        interaction_context = None
+        if self._context_assembler is not None:
+            try:
+                interaction_context = await self._context_assembler.assemble(
+                    self.customer_id,
+                    relevant_domains={domain} if domain else set(),
+                )
+            except Exception as e:
+                logger.warning(f"Context assembly failed, proceeding without: {e}")
+
         task = SpecialistTask(
             description=task_description,
             customer_id=self.customer_id,
             business_context=state.business_context,
             domain_memories=domain_memories,
             prior_turns=prior_turns,
+            interaction_context=interaction_context,
         )
 
         # Record delegation start (fresh delegations only — follow-ups

--- a/src/agents/executive_assistant.py
+++ b/src/agents/executive_assistant.py
@@ -1649,13 +1649,16 @@ The key difference: automation tools give you software to configure. I give you 
 
         The specialist provides summary_for_ea as a hint but the EA owns
         phrasing. With an LLM we prompt it to speak as the configured
-        persona; without, the hint IS the response (it's already prose).
+        persona; without, tone-aware formatting is applied directly.
         """
+        tone = self._personality.get("tone", "professional")
+        tone_guidance = _TONE_GUIDANCE.get(tone, _TONE_GUIDANCE["professional"])
+
         if self.llm and result.summary_for_ea:
             synthesis_prompt = (
                 f"You are {self._personality['name']}, the Executive Assistant for {context.business_name or 'the customer'}. "
                 f"A specialist on your team just checked something for the customer. "
-                f"Relay this naturally in your own voice — warm, concise, no jargon:\n\n"
+                f"Relay this naturally in your own voice. {tone_guidance}\n\n"
                 f"{result.summary_for_ea}\n\n"
                 f"Supporting data: {json.dumps(result.payload)}"
             )
@@ -1665,7 +1668,46 @@ The key difference: automation tools give you software to configure. I give you 
             except Exception as e:
                 logger.warning(f"Synthesis LLM call failed, using specialist summary: {e}")
 
-        return result.summary_for_ea or f"I checked on that — here's what I found: {json.dumps(result.payload)}"
+        return self._apply_tone(result, tone)
+
+    @staticmethod
+    def _apply_tone(result: SpecialistResult, tone: str) -> str:
+        """Tone-aware formatting for the no-LLM path.
+
+        Professional: summary as-is (current behaviour).
+        Concise: strip filler, just the data.
+        Friendly: casual framing.
+        Detailed: append structured payload info.
+        """
+        summary = result.summary_for_ea
+        payload_json = json.dumps(result.payload)
+
+        if not summary:
+            return f"I checked on that — here's what I found: {payload_json}"
+
+        if tone == "concise":
+            # Strip common preamble patterns
+            import re as _re
+            stripped = _re.sub(
+                r"^(I can see|Here'?s what I found:?|I found that|Let me share)\s*",
+                "", summary, flags=_re.IGNORECASE,
+            ).strip()
+            return stripped or summary
+
+        if tone == "friendly":
+            return f"All done! {summary}"
+
+        if tone == "detailed":
+            details = ", ".join(
+                f"{k}: {v}" for k, v in result.payload.items()
+                if k != "memories_consulted"
+            )
+            if details:
+                return f"{summary}\n\nDetails: {details}"
+            return summary
+
+        # professional (default) or unknown
+        return summary
 
     async def _handle_general_assistance(self, state: ConversationState) -> ConversationState:
         """Handle general business assistance requests"""

--- a/src/agents/specialists/finance.py
+++ b/src/agents/specialists/finance.py
@@ -7,6 +7,9 @@ summaries, and spending queries — all from conversation data passed
 in through SpecialistTask. No external accounting integrations, no
 direct memory-client access.
 
+Pattern awareness: expense entries consult InteractionContext for baseline
+deviation and budget overspend, surfacing warnings in the EA summary.
+
 Routing overlap with social_media is the interesting bit: "$500 on
 Facebook ads" is a finance action (track it) even though Facebook is
 a social keyword. "How much does Instagram advertising cost?" is a
@@ -187,6 +190,7 @@ class FinanceSpecialist(SpecialistAgent):
     # --- Assessment ---------------------------------------------------------
 
     def assess_task(self, task_description: str, context: "BusinessContext") -> TaskAssessment:
+        """Score finance confidence from dollar signs, action verbs, and category keywords."""
         text = task_description.lower()
 
         confidence = 0.0
@@ -242,6 +246,7 @@ class FinanceSpecialist(SpecialistAgent):
     # --- Execution ----------------------------------------------------------
 
     async def execute_task(self, task: SpecialistTask) -> SpecialistResult:
+        """Route to expense entry, summary, or portfolio; stage anomalies on completion."""
         text = task.description.lower()
 
         # Route to the right handler based on intent.
@@ -287,6 +292,7 @@ class FinanceSpecialist(SpecialistAgent):
     # --- Expense entry ------------------------------------------------------
 
     def _handle_expense_entry(self, task: SpecialistTask) -> SpecialistResult:
+        """Extract amount/vendor/category from multi-turn corpus; ask for clarification if incomplete."""
         # Pool the current message with prior customer turns so multi-turn
         # clarification works: the amount might be in task.description and
         # the vendor in a prior turn, or vice versa.
@@ -352,6 +358,7 @@ class FinanceSpecialist(SpecialistAgent):
     async def _maybe_stage_anomaly(
         self, customer_id: str, amount: float, category: str,
     ) -> None:
+        """Record the transaction and queue a domain event if it exceeds 2x baseline."""
         # Best-effort. A dead Redis or a slow pipe must not break expense
         # tracking — that's the primary path, this is the side channel.
         try:

--- a/src/agents/specialists/finance.py
+++ b/src/agents/specialists/finance.py
@@ -338,6 +338,9 @@ class FinanceSpecialist(SpecialistAgent):
             + ")."
         )
 
+        # Pattern awareness: deviation notes and budget tracking
+        summary += self._enrichment_notes(task, amount, category)
+
         return SpecialistResult(
             status=SpecialistStatus.COMPLETED,
             domain=self.domain,
@@ -390,7 +393,7 @@ class FinanceSpecialist(SpecialistAgent):
 
         # Cash flow query → income/expense split
         if "cash flow" in text:
-            return self._build_cashflow_result(entries, len(memories))
+            return self._build_cashflow_result(entries, len(memories), task=task)
 
         # Category-specific spend query → filter + total
         requested_cat = self._requested_category(text)
@@ -419,9 +422,11 @@ class FinanceSpecialist(SpecialistAgent):
             )
 
         # Generic spending summary → all-category breakdown
-        return self._build_cashflow_result(entries, len(memories))
+        return self._build_cashflow_result(entries, len(memories), task=task)
 
-    def _build_cashflow_result(self, entries: List[Dict], mem_count: int) -> SpecialistResult:
+    def _build_cashflow_result(
+        self, entries: List[Dict], mem_count: int, task: Optional[SpecialistTask] = None,
+    ) -> SpecialistResult:
         income = sum(e["amount"] for e in entries if e["is_income"])
         expenses = sum(e["amount"] for e in entries if not e["is_income"])
         net = income - expenses
@@ -453,6 +458,14 @@ class FinanceSpecialist(SpecialistAgent):
                 top = max(category_totals.items(), key=lambda kv: kv[1])
                 summary += f" Biggest outlay: {top[0]} at ${top[1]:,.2f}."
 
+            # Baseline comparison when context available
+            if task and task.interaction_context and task.interaction_context.finance_snapshot:
+                baseline = task.interaction_context.finance_snapshot.transaction_baseline
+                if baseline is not None and baseline > 0 and len(entries) > 0:
+                    avg_expense = expenses / max(1, sum(1 for e in entries if not e["is_income"]))
+                    if avg_expense > 0:
+                        summary += f" Average transaction: ${avg_expense:,.0f} (baseline ~${baseline:,.0f})."
+
         return SpecialistResult(
             status=SpecialistStatus.COMPLETED,
             domain=self.domain,
@@ -460,6 +473,44 @@ class FinanceSpecialist(SpecialistAgent):
             confidence=0.7,
             summary_for_ea=summary,
         )
+
+    # --- Pattern awareness (enrichment) ------------------------------------
+
+    @staticmethod
+    def _enrichment_notes(task: SpecialistTask, amount: float, category: str) -> str:
+        """Append deviation and budget notes when context is available."""
+        ic = task.interaction_context
+        if ic is None or ic.finance_snapshot is None:
+            return ""
+
+        parts: list[str] = []
+        snap = ic.finance_snapshot
+
+        # Deviation from baseline
+        if snap.transaction_baseline is not None and snap.transaction_baseline > 0:
+            ratio = amount / snap.transaction_baseline
+            if ratio > 2.0:
+                parts.append(
+                    f" That's higher than your usual ~${snap.transaction_baseline:,.0f}."
+                )
+
+        # Budget tracking
+        budget_info = snap.budget_status.get(category)
+        if budget_info and "limit" in budget_info:
+            limit = budget_info["limit"]
+            spent = budget_info.get("spent", 0) + amount
+            remaining = limit - spent
+            if remaining > 0:
+                parts.append(
+                    f" Budget: ${spent:,.0f} of ${limit:,.0f} {category} budget used"
+                    f" (${remaining:,.0f} remaining)."
+                )
+            else:
+                parts.append(
+                    f" Heads up: that puts you over your ${limit:,.0f} {category} budget."
+                )
+
+        return "".join(parts)
 
     # --- Portfolio valuation ------------------------------------------------
 

--- a/src/agents/specialists/scheduling.py
+++ b/src/agents/specialists/scheduling.py
@@ -367,7 +367,11 @@ class SchedulingSpecialist(SpecialistAgent):
                 clarification_question="What time works for this?",
             )
 
-        duration = self._parse_duration(text) or timedelta(minutes=60)
+        explicit_duration = self._parse_duration(text)
+        if explicit_duration is not None:
+            duration = explicit_duration
+        else:
+            duration = self._learned_duration(task) or timedelta(minutes=60)
         attendees = self._parse_attendees(corpus)
         title = self._derive_title(corpus, attendees)
         end = when + duration
@@ -387,6 +391,22 @@ class SchedulingSpecialist(SpecialistAgent):
             attendees=attendees,
         )
 
+        # Record preference for future learning
+        if self._proactive is not None:
+            try:
+                dur_min = int(duration.total_seconds() // 60)
+                await self._proactive.record_scheduling_preference(
+                    task.customer_id, dur_min, when.hour,
+                )
+            except Exception:
+                logger.exception("Preference recording failed; continuing")
+
+        summary = (
+            f"Booked: {evt.title} on {evt.start.strftime('%Y-%m-%d %H:%M')} "
+            f"for {int(duration.total_seconds() // 60)}m."
+        )
+        summary += self._buffer_note(task, end)
+
         return SpecialistResult(
             status=SpecialistStatus.COMPLETED,
             domain=self.domain,
@@ -398,11 +418,44 @@ class SchedulingSpecialist(SpecialistAgent):
                 "attendees": list(evt.attendees),
             },
             confidence=0.85,
-            summary_for_ea=(
-                f"Booked: {evt.title} on {evt.start.strftime('%Y-%m-%d %H:%M')} "
-                f"for {int(duration.total_seconds() // 60)}m."
-            ),
+            summary_for_ea=summary,
         )
+
+    @staticmethod
+    def _learned_duration(task: SpecialistTask) -> Optional[timedelta]:
+        """Pull preferred meeting duration from interaction context."""
+        ic = task.interaction_context
+        if ic is None:
+            return None
+        prefs = ic.customer_preferences
+        if prefs and prefs.preferred_meeting_duration:
+            return timedelta(minutes=prefs.preferred_meeting_duration)
+        return None
+
+    @staticmethod
+    def _buffer_note(task: SpecialistTask, new_end: datetime) -> str:
+        """Warn if the new event ends too close to the next one."""
+        ic = task.interaction_context
+        if ic is None or ic.calendar_snapshot is None:
+            return ""
+        prefs = ic.customer_preferences
+        buffer = prefs.buffer_minutes if prefs else 0
+        if buffer <= 0:
+            return ""
+        events = ic.calendar_snapshot.events_next_24h or []
+        for evt in events:
+            start_raw = evt.get("start")
+            if not start_raw:
+                continue
+            try:
+                evt_start = datetime.fromisoformat(start_raw)
+            except (ValueError, TypeError):
+                continue
+            gap = (evt_start - new_end).total_seconds() / 60
+            if 0 <= gap < buffer:
+                title = evt.get("title", "next event")
+                return f" Heads up: that's back-to-back with {title} (only {int(gap)}m gap)."
+        return ""
 
     async def _maybe_stage_conflict(
         self, customer_id: str, title: str, start: datetime, end: datetime,
@@ -571,6 +624,16 @@ class SchedulingSpecialist(SpecialistAgent):
         start, end = self._resolve_window(text, default_span_days=5)
 
         slots = await self._calendar.find_slots(duration, start, end)
+
+        # Sort by preferred hours when available
+        preferred = self._preferred_hours(task)
+        if preferred and slots:
+            pref_set = set(preferred)
+            slots = sorted(
+                slots,
+                key=lambda s: (0 if s.start.hour in pref_set else 1, s.start),
+            )
+
         payload = {
             "duration_minutes": int(duration.total_seconds() // 60),
             "window_start": start.isoformat(),
@@ -598,6 +661,16 @@ class SchedulingSpecialist(SpecialistAgent):
             confidence=0.75,
             summary_for_ea=summary,
         )
+
+    @staticmethod
+    def _preferred_hours(task: SpecialistTask) -> List[int]:
+        ic = task.interaction_context
+        if ic is None:
+            return []
+        prefs = ic.customer_preferences
+        if prefs and prefs.preferred_hours:
+            return prefs.preferred_hours
+        return []
 
     # --- Ambiguity & candidate search ---------------------------------------
 

--- a/src/agents/specialists/scheduling.py
+++ b/src/agents/specialists/scheduling.py
@@ -14,6 +14,9 @@ specialist outscores us.
 
 The constructor takes an optional `clock` callable so tests can pin
 "tomorrow at 2pm" to a known reference. Defaults to `datetime.now`.
+
+Preference learning: duration and preferred hours from InteractionContext
+bias slot finding and default meeting length.
 """
 from __future__ import annotations
 
@@ -212,6 +215,7 @@ class SchedulingSpecialist(SpecialistAgent):
     def assess_task(
         self, task_description: str, context: "BusinessContext"
     ) -> TaskAssessment:
+        """Score scheduling confidence; damp when 'schedule' co-occurs with another domain's action noun."""
         text = task_description.lower()
 
         confidence = 0.0
@@ -255,6 +259,7 @@ class SchedulingSpecialist(SpecialistAgent):
     # --- Execution ----------------------------------------------------------
 
     async def execute_task(self, task: SpecialistTask) -> SpecialistResult:
+        """Dispatch confirmed follow-ups directly; otherwise classify intent and route."""
         if self._calendar is None:
             return SpecialistResult(
                 status=SpecialistStatus.FAILED,
@@ -295,6 +300,7 @@ class SchedulingSpecialist(SpecialistAgent):
     # --- Intent dispatch ----------------------------------------------------
 
     def _classify_intent(self, text: str) -> str:
+        """Keyword-first intent classification; most-specific cues win, fallback is overview."""
         # Order matters — more specific cues first.
         if any(c in text for c in ("find me", "find a slot", "find a time",
                                    "when can i meet", "find me a slot",
@@ -325,6 +331,7 @@ class SchedulingSpecialist(SpecialistAgent):
     async def _handle_overview(
         self, task: SpecialistTask, corpus: str, text: str
     ) -> SpecialistResult:
+        """List events for the mentioned day (default today)."""
         day = self._resolve_day(text)
         start = day.replace(hour=0, minute=0, second=0, microsecond=0)
         end = start + timedelta(days=1)
@@ -357,6 +364,7 @@ class SchedulingSpecialist(SpecialistAgent):
     async def _handle_create(
         self, task: SpecialistTask, corpus: str, text: str
     ) -> SpecialistResult:
+        """Parse time/duration/attendees, check conflicts, create the event, record preferences."""
         when = self._parse_datetime(text)
         if when is None:
             return SpecialistResult(
@@ -488,6 +496,7 @@ class SchedulingSpecialist(SpecialistAgent):
     async def _handle_reschedule(
         self, task: SpecialistTask, corpus: str, text: str
     ) -> SpecialistResult:
+        """Resolve the target event, parse destination time, update via calendar client."""
         candidates = await self._find_candidates(corpus, text)
         if len(candidates) != 1:
             return self._clarify_ambiguity(candidates, verb="reschedule")
@@ -588,6 +597,7 @@ class SchedulingSpecialist(SpecialistAgent):
     async def _handle_availability(
         self, task: SpecialistTask, corpus: str, text: str
     ) -> SpecialistResult:
+        """Check free/busy for the resolved window and list conflicts."""
         start, end = self._resolve_window(text)
         free = await self._calendar.is_free(start, end)
         conflicts = (
@@ -620,6 +630,7 @@ class SchedulingSpecialist(SpecialistAgent):
     async def _handle_slot_find(
         self, task: SpecialistTask, corpus: str, text: str
     ) -> SpecialistResult:
+        """Find open slots in the requested window; sort by preferred hours when available."""
         duration = self._parse_find_duration(text) or timedelta(minutes=30)
         start, end = self._resolve_window(text, default_span_days=5)
 

--- a/src/agents/specialists/workflows.py
+++ b/src/agents/specialists/workflows.py
@@ -96,10 +96,13 @@ class WorkflowSpecialist(SpecialistAgent):
         store: Optional["WorkflowStore"] = None,
         catalog: Optional["WorkflowCatalog"] = None,
         n8n_client_factory: Optional[Callable[..., "N8nClient"]] = None,
+        *,
+        proactive_state: Optional[Any] = None,
     ):
         self._store = store
         self._catalog = catalog
         self._client_factory = n8n_client_factory
+        self._proactive = proactive_state
 
     @property
     def domain(self) -> str:
@@ -196,16 +199,32 @@ class WorkflowSpecialist(SpecialistAgent):
             )
         active = [w for w in wfs if w["status"] == "active"]
         names = ", ".join(w["name"] for w in wfs)
+        summary = (
+            f"You have {len(wfs)} automation{'s' if len(wfs) != 1 else ''} "
+            f"({len(active)} active): {names}."
+        )
+
+        # Surface recent failures from interaction context
+        summary += self._failure_note(task)
+
         return SpecialistResult(
             status=SpecialistStatus.COMPLETED,
             domain=self.domain,
             payload={"workflows": wfs},
             confidence=0.9,
-            summary_for_ea=(
-                f"You have {len(wfs)} automation{'s' if len(wfs) != 1 else ''} "
-                f"({len(active)} active): {names}."
-            ),
+            summary_for_ea=summary,
         )
+
+    @staticmethod
+    def _failure_note(task: SpecialistTask) -> str:
+        ic = task.interaction_context
+        if ic is None or ic.workflow_snapshot is None:
+            return ""
+        failures = ic.workflow_snapshot.recent_failures
+        if not failures:
+            return ""
+        names = ", ".join(f.get("name", "unknown") for f in failures[:3])
+        return f" Heads up: recent issues with {names}."
 
     # --- Pause / resume / delete --------------------------------------------
 
@@ -322,17 +341,54 @@ class WorkflowSpecialist(SpecialistAgent):
             task.customer_id, wf_id, template.name, "active"
         )
 
+        summary = (
+            f"Done. '{template.name}' is deployed and active. "
+            f"You can manage it from the dashboard."
+        )
+
+        # Suggest related templates (best-effort)
+        suggestion = await self._suggest_related(
+            task.customer_id, template, task,
+        )
+        if suggestion:
+            summary += f" {suggestion}"
+
         return SpecialistResult(
             status=SpecialistStatus.COMPLETED,
             domain=self.domain,
             payload={"workflow_id": wf_id, "name": template.name,
                      "parameters": values},
             confidence=0.85,
-            summary_for_ea=(
-                f"Done. '{template.name}' is deployed and active. "
-                f"You can manage it from the dashboard."
-            ),
+            summary_for_ea=summary,
         )
+
+    async def _suggest_related(
+        self, customer_id: str, deployed: Any, task: SpecialistTask,
+    ) -> Optional[str]:
+        """Find a related template and suggest it, respecting cooldowns."""
+        if self._catalog is None or self._proactive is None:
+            return None
+        try:
+            all_templates = self._catalog.list_local()
+            for t in all_templates:
+                if t.id == deployed.id:
+                    continue
+                cooldown_key = f"wf_suggest:{t.id}"
+                if await self._proactive.is_cooling_down(customer_id, cooldown_key):
+                    continue
+                # Check for tag/integration overlap
+                overlap = (
+                    set(deployed.tags or []) & set(t.tags or [])
+                    or set(deployed.integrations or []) & set(t.integrations or [])
+                )
+                if overlap:
+                    await self._proactive.record_cooldown(
+                        customer_id, cooldown_key, 86400,
+                    )
+                    return f"You might also like '{t.name}'."
+        except Exception:
+            logger.exception("Related template suggestion failed; skipping")
+        return None
 
     def _resume_template_id(self, task: SpecialistTask) -> Optional[str]:
         # The EA carries specialist payload forward in prior_turns during

--- a/src/agents/specialists/workflows.py
+++ b/src/agents/specialists/workflows.py
@@ -11,6 +11,9 @@ Seams: WorkflowStore, WorkflowCatalog, and an N8nClient factory. All
 optional — the no-arg constructor works so the EA's importlib loop can
 instantiate it, but execute degrades to "not configured" until a store
 is wired in.
+
+Contextual enhancements: list surfaces recent failures from
+InteractionContext; deploy suggests related templates with cooldowns.
 """
 from __future__ import annotations
 
@@ -113,6 +116,7 @@ class WorkflowSpecialist(SpecialistAgent):
     def assess_task(
         self, task_description: str, context: "BusinessContext"
     ) -> TaskAssessment:
+        """Score automation confidence; damp when calendar nouns appear without recurrence markers."""
         text = task_description.lower()
 
         confidence = 0.0
@@ -155,6 +159,7 @@ class WorkflowSpecialist(SpecialistAgent):
     # --- Execution ----------------------------------------------------------
 
     async def execute_task(self, task: SpecialistTask) -> SpecialistResult:
+        """Classify intent and dispatch. Requires a configured workflow store."""
         if self._store is None:
             return self._failed("workflow store not configured")
 
@@ -170,6 +175,7 @@ class WorkflowSpecialist(SpecialistAgent):
         return await handler(task, text)
 
     def _classify_intent(self, text: str) -> str:
+        """Keyword intent dispatch: list, pause, resume, delete, or deploy (default)."""
         if any(p in text for p in ("what automation", "what workflow",
                                    "list my automation", "list my workflow",
                                    "automations do i have",
@@ -188,6 +194,7 @@ class WorkflowSpecialist(SpecialistAgent):
     # --- List ---------------------------------------------------------------
 
     async def _handle_list(self, task: SpecialistTask, text: str) -> SpecialistResult:
+        """List customer automations; append failure context from InteractionContext."""
         wfs = await self._store.list_workflows(task.customer_id)
         if not wfs:
             return SpecialistResult(
@@ -217,6 +224,7 @@ class WorkflowSpecialist(SpecialistAgent):
 
     @staticmethod
     def _failure_note(task: SpecialistTask) -> str:
+        """Build a warning string from recent workflow failures in the snapshot."""
         ic = task.interaction_context
         if ic is None or ic.workflow_snapshot is None:
             return ""
@@ -297,6 +305,7 @@ class WorkflowSpecialist(SpecialistAgent):
     # --- Deploy -------------------------------------------------------------
 
     async def _handle_deploy(self, task: SpecialistTask, text: str) -> SpecialistResult:
+        """Match a template, collect parameters across turns, deploy to n8n, suggest related."""
         if self._catalog is None:
             return self._failed("template catalog not configured")
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -207,6 +207,12 @@ def create_default_app() -> FastAPI:  # pragma: no cover
     import os as _os
     ea_max = int(_os.environ.get("EA_REGISTRY_MAX_SIZE", "128"))
 
+    from src.agents.context import ContextAssembler
+    context_assembler = ContextAssembler(
+        proactive_store=proactive_store,
+        settings_redis=redis_client,
+    )
+
     def _ea_factory(cid: str) -> ExecutiveAssistant:
         ea = ExecutiveAssistant(customer_id=cid)
         # audit_logger is optional on the EA; when present,
@@ -216,6 +222,8 @@ def create_default_app() -> FastAPI:  # pragma: no cover
         # The EA's own memory client is on db=hash(customer_id)%16.
         # Personality settings live in db 0, so hand it the shared client.
         ea.settings_redis = redis_client
+        # Cross-domain context for specialist delegation.
+        ea._context_assembler = context_assembler
         return ea
 
     ea_registry = EARegistry(factory=_ea_factory, max_size=ea_max)

--- a/src/proactive/state.py
+++ b/src/proactive/state.py
@@ -324,3 +324,23 @@ class ProactiveStateStore:
         if val is None:
             return 0
         return int(val.decode() if isinstance(val, bytes) else val)
+
+    # -- Topic counting (workflow suggestion triggers) -------------------------
+
+    async def increment_topic_count(
+        self, customer_id: str, topic: str,
+    ) -> int:
+        key = _key(customer_id, "wf_topic_counts")
+        result = await self._r.hincrby(key, topic, 1)
+        return int(result)
+
+    async def get_topic_counts(
+        self, customer_id: str,
+    ) -> Dict[str, int]:
+        key = _key(customer_id, "wf_topic_counts")
+        raw = await self._r.hgetall(key)
+        return {
+            (k.decode() if isinstance(k, bytes) else k):
+            int(v.decode() if isinstance(v, bytes) else v)
+            for k, v in raw.items()
+        }

--- a/src/proactive/state.py
+++ b/src/proactive/state.py
@@ -277,3 +277,50 @@ class ProactiveStateStore:
             if cursor == 0:
                 break
         return budgets
+
+    # -- Scheduling preference learning ----------------------------------------
+    # Durations stored as a capped list (most recent 50). Hours stored in a
+    # sorted set keyed by score (frequency). Buffer is a plain string.
+
+    _SCHED_MAX_SAMPLES = 50
+
+    async def record_scheduling_preference(
+        self, customer_id: str, duration_minutes: int, hour: int,
+    ) -> None:
+        dur_key = _key(customer_id, "sched", "durations")
+        hour_key = _key(customer_id, "sched", "preferred_hours")
+        pipe = self._r.pipeline()
+        pipe.rpush(dur_key, str(duration_minutes))
+        pipe.ltrim(dur_key, -self._SCHED_MAX_SAMPLES, -1)
+        pipe.zincrby(hour_key, 1, str(hour))
+        await pipe.execute()
+
+    async def get_preferred_duration(self, customer_id: str) -> Optional[int]:
+        key = _key(customer_id, "sched", "durations")
+        raw = await self._r.lrange(key, 0, -1)
+        if not raw:
+            return None
+        durations = [
+            int(v.decode() if isinstance(v, bytes) else v) for v in raw
+        ]
+        # Return mode (most common duration)
+        from collections import Counter
+        counts = Counter(durations)
+        return counts.most_common(1)[0][0]
+
+    async def get_preferred_hours(self, customer_id: str) -> List[int]:
+        key = _key(customer_id, "sched", "preferred_hours")
+        # ZREVRANGE returns highest-score first
+        raw = await self._r.zrevrange(key, 0, -1)
+        return [int(v.decode() if isinstance(v, bytes) else v) for v in raw]
+
+    async def set_buffer_minutes(self, customer_id: str, minutes: int) -> None:
+        key = _key(customer_id, "sched", "buffer_minutes")
+        await self._r.set(key, str(minutes))
+
+    async def get_buffer_minutes(self, customer_id: str) -> int:
+        key = _key(customer_id, "sched", "buffer_minutes")
+        val = await self._r.get(key)
+        if val is None:
+            return 0
+        return int(val.decode() if isinstance(val, bytes) else val)

--- a/src/proactive/state.py
+++ b/src/proactive/state.py
@@ -241,3 +241,39 @@ class ProactiveStateStore:
     ) -> None:
         key = _key(customer_id, "wf_last_exec", workflow_id)
         await self._r.set(key, execution_id)
+
+    # -- Budget tracking (finance pattern awareness) -------------------------
+
+    async def set_budget(
+        self, customer_id: str, category: str, limit: float,
+    ) -> None:
+        key = _key(customer_id, "budget", category)
+        await self._r.set(key, str(limit))
+
+    async def get_budget(
+        self, customer_id: str, category: str,
+    ) -> Optional[float]:
+        key = _key(customer_id, "budget", category)
+        val = await self._r.get(key)
+        if val is None:
+            return None
+        raw = val.decode() if isinstance(val, bytes) else val
+        return float(raw)
+
+    async def get_all_budgets(self, customer_id: str) -> Dict[str, float]:
+        # Scan for budget keys. Pattern: proactive:{cid}:budget:*
+        prefix = _key(customer_id, "budget", "")
+        budgets: Dict[str, float] = {}
+        cursor = 0
+        while True:
+            cursor, keys = await self._r.scan(cursor, match=f"{prefix}*", count=50)
+            for k in keys:
+                raw_key = k.decode() if isinstance(k, bytes) else k
+                category = raw_key.split(":")[-1]
+                val = await self._r.get(k)
+                if val is not None:
+                    raw_val = val.decode() if isinstance(val, bytes) else val
+                    budgets[category] = float(raw_val)
+            if cursor == 0:
+                break
+        return budgets

--- a/tests/unit/test_ea_delegation.py
+++ b/tests/unit/test_ea_delegation.py
@@ -526,3 +526,95 @@ class TestLastSpecialistDomain:
         )
 
         assert ea.last_specialist_domain is None
+
+
+# --- Context assembler wiring -----------------------------------------------
+
+class TestContextAssemblerWiring:
+    def test_context_assembler_defaults_to_none(self, ea):
+        """Same injection pattern as audit_logger — set by factory, not ctor."""
+        assert ea._context_assembler is None
+
+    @pytest.mark.asyncio
+    async def test_delegation_passes_interaction_context_when_assembler_wired(self, ea, state):
+        """When a ContextAssembler is wired, specialist receives non-None context."""
+        from src.agents.context import ContextAssembler, InteractionContext, CustomerPreferences
+
+        received = []
+
+        async def _capture(task):
+            received.append(task)
+            return SpecialistResult(
+                status=SpecialistStatus.COMPLETED, domain="social_media",
+                payload={}, confidence=0.8, summary_for_ea="ok",
+            )
+
+        spec = _make_specialist()
+        spec.execute_task = _capture
+        ea.delegation_registry = DelegationRegistry()
+        ea.delegation_registry.register(spec)
+        state.delegation_target = "social_media"
+
+        # Wire a mock assembler that returns a minimal InteractionContext
+        assembler = AsyncMock(spec=ContextAssembler)
+        assembler.assemble = AsyncMock(return_value=InteractionContext(
+            customer_preferences=CustomerPreferences(tone="friendly"),
+        ))
+        ea._context_assembler = assembler
+
+        await ea._delegate_to_specialist(state)
+
+        assert len(received) == 1
+        assert received[0].interaction_context is not None
+        assert received[0].interaction_context.customer_preferences.tone == "friendly"
+
+    @pytest.mark.asyncio
+    async def test_delegation_works_without_context_assembler(self, ea, state):
+        """No assembler wired → interaction_context is None, no crash."""
+        received = []
+
+        async def _capture(task):
+            received.append(task)
+            return SpecialistResult(
+                status=SpecialistStatus.COMPLETED, domain="social_media",
+                payload={}, confidence=0.8, summary_for_ea="ok",
+            )
+
+        spec = _make_specialist()
+        spec.execute_task = _capture
+        ea.delegation_registry = DelegationRegistry()
+        ea.delegation_registry.register(spec)
+        state.delegation_target = "social_media"
+        ea._context_assembler = None
+
+        await ea._delegate_to_specialist(state)
+
+        assert len(received) == 1
+        assert received[0].interaction_context is None
+
+    @pytest.mark.asyncio
+    async def test_context_assembly_failure_doesnt_block_delegation(self, ea, state):
+        """Assembler raises → delegation proceeds with None context."""
+        received = []
+
+        async def _capture(task):
+            received.append(task)
+            return SpecialistResult(
+                status=SpecialistStatus.COMPLETED, domain="social_media",
+                payload={}, confidence=0.8, summary_for_ea="ok",
+            )
+
+        spec = _make_specialist()
+        spec.execute_task = _capture
+        ea.delegation_registry = DelegationRegistry()
+        ea.delegation_registry.register(spec)
+        state.delegation_target = "social_media"
+
+        broken_assembler = AsyncMock()
+        broken_assembler.assemble = AsyncMock(side_effect=RuntimeError("assembler boom"))
+        ea._context_assembler = broken_assembler
+
+        await ea._delegate_to_specialist(state)
+
+        assert len(received) == 1
+        assert received[0].interaction_context is None

--- a/tests/unit/test_ea_delegation_recording.py
+++ b/tests/unit/test_ea_delegation_recording.py
@@ -47,6 +47,8 @@ def _make_ea_with_recorder(recorder=None, specialist_result=None):
     ea.delegation_recorder = recorder
     ea.audit_logger = None
     ea.specialist_timeout = 15.0
+    ea._context_assembler = None
+    ea._personality = {"tone": "professional"}
 
     # Minimal memory mock
     ea.memory = AsyncMock()

--- a/tests/unit/test_finance_enhanced.py
+++ b/tests/unit/test_finance_enhanced.py
@@ -100,7 +100,7 @@ class TestExpenseDeviation:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        assert "higher than" in result.summary_for_ea.lower() or "usual" in result.summary_for_ea.lower()
+        assert "higher than your usual" in result.summary_for_ea.lower()
 
     @pytest.mark.asyncio
     async def test_no_deviation_note_within_normal_range(self, specialist, ctx, store):
@@ -146,6 +146,24 @@ class TestBudgetTracking:
         assert result.status == SpecialistStatus.COMPLETED
         summary_lower = result.summary_for_ea.lower()
         assert "budget" in summary_lower
+        # Should mention the spent amount and the limit
+        assert "$3,000" in result.summary_for_ea or "$2,600" in result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_warning(self, specialist, ctx, store):
+        """Expense pushes past budget limit → 'over your budget' warning."""
+        await store.set_budget(CUSTOMER_ID, "marketing", 500.0)
+
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(
+                budget_status={"marketing": {"limit": 500.0, "spent": 450.0}},
+            ),
+        )
+        task = _task("track $200 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "over" in result.summary_for_ea.lower()
 
     @pytest.mark.asyncio
     async def test_no_budget_mention_without_budget_set(self, specialist, ctx):
@@ -177,13 +195,15 @@ class TestSummaryComparison:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        # Should have some reference to baseline or average
+        # Should contain baseline comparison with dollar amounts
         summary_lower = result.summary_for_ea.lower()
-        assert "average" in summary_lower or "baseline" in summary_lower or "$" in summary_lower
+        assert "baseline" in summary_lower or "average" in summary_lower
+        # Must reference the baseline figure from context
+        assert "$300" in result.summary_for_ea
 
     @pytest.mark.asyncio
-    async def test_summary_works_without_context(self, specialist, ctx):
-        """No interaction_context → summary still works (existing behavior)."""
+    async def test_summary_no_baseline_note_without_context(self, specialist, ctx):
+        """No interaction_context → no baseline mention in summary."""
         memories = [
             {"content": "Tracked $400 for marketing ads"},
         ]
@@ -191,4 +211,22 @@ class TestSummaryComparison:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        assert result.summary_for_ea is not None
+        assert "baseline" not in result.summary_for_ea.lower()
+        assert "average" not in result.summary_for_ea.lower()
+        # Should still produce a useful spending summary
+        assert "$400" in result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_deviation_at_exactly_2x_does_not_trigger(self, specialist, ctx, store):
+        """Amount == 2x baseline → threshold is >2x, so no note."""
+        for _ in range(4):
+            await store.record_transaction(CUSTOMER_ID, 200.0)
+
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(transaction_baseline=200.0),
+        )
+        task = _task("track $400 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "higher than your usual" not in result.summary_for_ea.lower()

--- a/tests/unit/test_finance_enhanced.py
+++ b/tests/unit/test_finance_enhanced.py
@@ -1,0 +1,194 @@
+"""
+Tests for finance specialist enhancements: pattern awareness.
+
+- Running averages: mention deviations ("higher than usual")
+- Budget tracking: reference budget limits
+- Period comparisons: include vs baseline
+- All enhancements degrade gracefully without interaction_context
+"""
+import pytest
+import fakeredis.aioredis
+from unittest.mock import AsyncMock
+
+from src.agents.base.specialist import SpecialistTask, SpecialistStatus
+from src.agents.context import InteractionContext, FinanceSnapshot, CustomerPreferences
+from src.agents.executive_assistant import BusinessContext
+from src.agents.specialists.finance import FinanceSpecialist
+from src.proactive.state import ProactiveStateStore
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def store(fake_redis):
+    return ProactiveStateStore(fake_redis)
+
+
+@pytest.fixture
+def specialist(store):
+    return FinanceSpecialist(proactive_state=store)
+
+
+@pytest.fixture
+def ctx():
+    return BusinessContext(
+        business_name="Sparkle & Shine",
+        industry="jewelry",
+        current_tools=["QuickBooks"],
+    )
+
+
+CUSTOMER_ID = "cust_fin_test"
+
+
+def _task(description, ctx, *, interaction_context=None, memories=None):
+    return SpecialistTask(
+        description=description,
+        customer_id=CUSTOMER_ID,
+        business_context=ctx,
+        domain_memories=memories or [],
+        interaction_context=interaction_context,
+    )
+
+
+# --- ProactiveStateStore: budget methods ------------------------------------
+
+class TestBudgetStorage:
+    @pytest.mark.asyncio
+    async def test_set_and_get_budget(self, store):
+        await store.set_budget(CUSTOMER_ID, "marketing", 3000.0)
+        result = await store.get_budget(CUSTOMER_ID, "marketing")
+        assert result == 3000.0
+
+    @pytest.mark.asyncio
+    async def test_get_budget_returns_none_when_not_set(self, store):
+        result = await store.get_budget(CUSTOMER_ID, "nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_budgets(self, store):
+        await store.set_budget(CUSTOMER_ID, "marketing", 3000.0)
+        await store.set_budget(CUSTOMER_ID, "software", 500.0)
+        budgets = await store.get_all_budgets(CUSTOMER_ID)
+        assert budgets == {"marketing": 3000.0, "software": 500.0}
+
+    @pytest.mark.asyncio
+    async def test_get_all_budgets_empty(self, store):
+        budgets = await store.get_all_budgets(CUSTOMER_ID)
+        assert budgets == {}
+
+
+# --- Expense entry: deviation notes -----------------------------------------
+
+class TestExpenseDeviation:
+    @pytest.mark.asyncio
+    async def test_notes_deviation_when_above_baseline(self, specialist, ctx, store):
+        """Amount > 2x baseline → summary mentions 'higher than usual'."""
+        # Build a baseline: 4 transactions at $200
+        for _ in range(4):
+            await store.record_transaction(CUSTOMER_ID, 200.0)
+
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(transaction_baseline=200.0),
+        )
+        task = _task("track $500 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "higher than" in result.summary_for_ea.lower() or "usual" in result.summary_for_ea.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_deviation_note_within_normal_range(self, specialist, ctx, store):
+        """Amount within normal range → no deviation note."""
+        for _ in range(4):
+            await store.record_transaction(CUSTOMER_ID, 200.0)
+
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(transaction_baseline=200.0),
+        )
+        task = _task("track $250 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "higher than" not in result.summary_for_ea.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_deviation_note_without_context(self, specialist, ctx):
+        """No interaction_context → existing behavior, no crash."""
+        task = _task("track $5000 to Acme Corp for marketing", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "higher than" not in result.summary_for_ea.lower()
+
+
+# --- Expense entry: budget tracking -----------------------------------------
+
+class TestBudgetTracking:
+    @pytest.mark.asyncio
+    async def test_mentions_budget_remaining(self, specialist, ctx, store):
+        """Budget set for category → response mentions remaining budget."""
+        await store.set_budget(CUSTOMER_ID, "marketing", 3000.0)
+
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(
+                budget_status={"marketing": {"limit": 3000.0, "spent": 2400.0}},
+            ),
+        )
+        task = _task("track $200 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        summary_lower = result.summary_for_ea.lower()
+        assert "budget" in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_no_budget_mention_without_budget_set(self, specialist, ctx):
+        """No budget configured → no budget mention."""
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(),
+        )
+        task = _task("track $200 to Acme Corp for marketing", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "budget" not in result.summary_for_ea.lower()
+
+
+# --- Summary: baseline comparison ------------------------------------------
+
+class TestSummaryComparison:
+    @pytest.mark.asyncio
+    async def test_summary_includes_baseline_context(self, specialist, ctx):
+        """When baseline available, summary mentions comparison."""
+        ic = InteractionContext(
+            finance_snapshot=FinanceSnapshot(transaction_baseline=300.0),
+        )
+        memories = [
+            {"content": "Tracked $400 for marketing ads"},
+            {"content": "Tracked $200 for software subscription"},
+        ]
+        task = _task("how much did I spend?", ctx, interaction_context=ic, memories=memories)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        # Should have some reference to baseline or average
+        summary_lower = result.summary_for_ea.lower()
+        assert "average" in summary_lower or "baseline" in summary_lower or "$" in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_summary_works_without_context(self, specialist, ctx):
+        """No interaction_context → summary still works (existing behavior)."""
+        memories = [
+            {"content": "Tracked $400 for marketing ads"},
+        ]
+        task = _task("how much did I spend?", ctx, memories=memories)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert result.summary_for_ea is not None

--- a/tests/unit/test_interaction_context.py
+++ b/tests/unit/test_interaction_context.py
@@ -102,7 +102,8 @@ class TestInteractionContextDataclass:
         assert ctx.finance_snapshot is None
         assert ctx.workflow_snapshot is None
         assert ctx.pending_notifications == []
-        assert ctx.customer_preferences is not None
+        assert isinstance(ctx.customer_preferences, CustomerPreferences)
+        assert ctx.customer_preferences.tone == "professional"
         assert ctx.delegation_history == []
 
     def test_calendar_snapshot_fields(self):
@@ -399,5 +400,6 @@ class TestAssemblerNotifications:
             CUSTOMER_ID,
             relevant_domains=set(),
         )
-        assert len(ctx.pending_notifications) >= 1
+        assert len(ctx.pending_notifications) == 1
         assert ctx.pending_notifications[0]["domain"] == "finance"
+        assert ctx.pending_notifications[0]["title"] == "Unusual expense"

--- a/tests/unit/test_interaction_context.py
+++ b/tests/unit/test_interaction_context.py
@@ -1,0 +1,403 @@
+"""
+Tests for InteractionContext and ContextAssembler.
+
+The shared context layer is assembled once per interaction and passed
+read-only to whichever specialist handles the delegation. It aggregates
+lightweight snapshots from each domain (calendar, finance, workflows,
+notifications) with per-source timeouts so a slow domain never blocks
+the response.
+
+Tests first — implementation follows.
+"""
+import asyncio
+import json
+from datetime import datetime, timezone
+
+import pytest
+import fakeredis.aioredis
+from unittest.mock import AsyncMock, MagicMock
+
+from src.agents.context import (
+    CalendarSnapshot,
+    ContextAssembler,
+    CustomerPreferences,
+    DelegationRecord,
+    FinanceSnapshot,
+    InteractionContext,
+    WorkflowSnapshot,
+)
+from src.proactive.state import ProactiveStateStore
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def proactive_store(fake_redis):
+    return ProactiveStateStore(fake_redis)
+
+
+@pytest.fixture
+def settings_redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def calendar_client():
+    """Mock calendar client returning two events with real datetimes."""
+    client = AsyncMock()
+    client.list_events = AsyncMock(return_value=[
+        MagicMock(
+            id="evt1", title="Standup",
+            start=datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 21, 9, 30, tzinfo=timezone.utc),
+            attendees=("Alice",), location=None,
+        ),
+        MagicMock(
+            id="evt2", title="Client Call",
+            start=datetime(2026, 3, 21, 14, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 21, 15, 0, tzinfo=timezone.utc),
+            attendees=("Bob",), location="Zoom",
+        ),
+    ])
+    client.is_free = AsyncMock(return_value=True)
+    return client
+
+
+@pytest.fixture
+def workflow_store():
+    """Mock workflow store with two active workflows."""
+    store = AsyncMock()
+    store.list_workflows = AsyncMock(return_value=[
+        {"workflow_id": "wf1", "name": "Monday Reports", "status": "active"},
+        {"workflow_id": "wf2", "name": "Invoice Tracker", "status": "active"},
+    ])
+    return store
+
+
+@pytest.fixture
+def assembler(proactive_store, settings_redis):
+    return ContextAssembler(
+        proactive_store=proactive_store,
+        settings_redis=settings_redis,
+        source_timeout=2.0,
+    )
+
+
+CUSTOMER_ID = "cust_ctx_test"
+
+
+# --- InteractionContext dataclass -------------------------------------------
+
+class TestInteractionContextDataclass:
+    def test_default_construction(self):
+        """All fields have sensible defaults."""
+        ctx = InteractionContext()
+        assert ctx.recent_conversation_summary is None
+        assert ctx.calendar_snapshot is None
+        assert ctx.finance_snapshot is None
+        assert ctx.workflow_snapshot is None
+        assert ctx.pending_notifications == []
+        assert ctx.customer_preferences is not None
+        assert ctx.delegation_history == []
+
+    def test_calendar_snapshot_fields(self):
+        snap = CalendarSnapshot(events_next_24h=[{"id": "e1"}], has_conflicts=True)
+        assert snap.has_conflicts is True
+        assert len(snap.events_next_24h) == 1
+
+    def test_finance_snapshot_fields(self):
+        snap = FinanceSnapshot(
+            transaction_baseline=250.0,
+            recent_expense_total=1200.0,
+            top_category="marketing",
+            budget_status={"marketing": {"limit": 3000, "spent": 1200}},
+        )
+        assert snap.transaction_baseline == 250.0
+        assert snap.budget_status["marketing"]["limit"] == 3000
+
+    def test_workflow_snapshot_fields(self):
+        snap = WorkflowSnapshot(
+            active_count=2,
+            workflow_names=["A", "B"],
+            recent_failures=[{"wf": "A", "error": "timeout"}],
+        )
+        assert snap.active_count == 2
+        assert len(snap.recent_failures) == 1
+
+    def test_customer_preferences_defaults(self):
+        prefs = CustomerPreferences()
+        assert prefs.tone == "professional"
+        assert prefs.language == "en"
+        assert prefs.business_type == ""
+
+    def test_delegation_record_fields(self):
+        rec = DelegationRecord(domain="finance", status="completed", timestamp="2026-03-21T10:00:00Z")
+        assert rec.domain == "finance"
+
+
+# --- ContextAssembler: happy path -------------------------------------------
+
+class TestAssemblerHappyPath:
+    @pytest.mark.asyncio
+    async def test_assembles_with_all_sources(
+        self, assembler, proactive_store, settings_redis, calendar_client, workflow_store,
+    ):
+        """All sources wired and healthy → full context."""
+        # Seed finance data
+        for _ in range(4):
+            await proactive_store.record_transaction(CUSTOMER_ID, 200.0)
+
+        # Seed personality settings
+        await settings_redis.set(f"settings:{CUSTOMER_ID}", json.dumps({
+            "personality": {"tone": "friendly", "name": "Aria", "language": "en"},
+            "working_hours": {"start": "09:00", "end": "17:00", "timezone": "US/Eastern"},
+        }))
+
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"scheduling", "finance", "workflows"},
+            calendar_client=calendar_client,
+            workflow_store=workflow_store,
+            conversation_summary="Discussed marketing budget earlier.",
+        )
+
+        assert ctx.recent_conversation_summary == "Discussed marketing budget earlier."
+        assert ctx.calendar_snapshot is not None
+        assert len(ctx.calendar_snapshot.events_next_24h) == 2
+        assert ctx.finance_snapshot is not None
+        assert ctx.finance_snapshot.transaction_baseline is not None
+        assert ctx.workflow_snapshot is not None
+        assert ctx.workflow_snapshot.active_count == 2
+        assert ctx.customer_preferences.tone == "friendly"
+
+    @pytest.mark.asyncio
+    async def test_conversation_summary_passthrough(self, assembler):
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains=set(),
+            conversation_summary="Talked about invoices.",
+        )
+        assert ctx.recent_conversation_summary == "Talked about invoices."
+
+
+# --- ContextAssembler: missing sources → graceful degradation ---------------
+
+class TestAssemblerDegradation:
+    @pytest.mark.asyncio
+    async def test_calendar_snapshot_none_when_no_client(self, assembler):
+        """No calendar client → snapshot is None, not an error."""
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"scheduling"},
+            calendar_client=None,
+        )
+        assert ctx.calendar_snapshot is None
+
+    @pytest.mark.asyncio
+    async def test_workflow_snapshot_none_when_no_store(self, assembler):
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"workflows"},
+            workflow_store=None,
+        )
+        assert ctx.workflow_snapshot is None
+
+    @pytest.mark.asyncio
+    async def test_finance_snapshot_none_when_no_transactions(self, assembler):
+        """No transaction history → baseline is None."""
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"finance"},
+        )
+        assert ctx.finance_snapshot is not None
+        assert ctx.finance_snapshot.transaction_baseline is None
+
+    @pytest.mark.asyncio
+    async def test_preferences_defaults_when_settings_missing(self, assembler):
+        """No settings in Redis → defaults."""
+        ctx = await assembler.assemble(CUSTOMER_ID, relevant_domains=set())
+        assert ctx.customer_preferences.tone == "professional"
+        assert ctx.customer_preferences.language == "en"
+
+
+# --- ContextAssembler: lazy loading (relevant_domains) ----------------------
+
+class TestAssemblerLazyLoading:
+    @pytest.mark.asyncio
+    async def test_irrelevant_domain_not_queried(self, assembler, calendar_client):
+        """When relevant_domains is {'finance'}, calendar client not called."""
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"finance"},
+            calendar_client=calendar_client,
+        )
+        assert ctx.calendar_snapshot is None
+        calendar_client.list_events.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_relevant_domain_queried(self, assembler, calendar_client):
+        """When relevant_domains includes 'scheduling', calendar client IS called."""
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"scheduling"},
+            calendar_client=calendar_client,
+        )
+        assert ctx.calendar_snapshot is not None
+        calendar_client.list_events.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_domains_fetches_all_lightweight(
+        self, assembler, calendar_client, workflow_store,
+    ):
+        """Empty relevant_domains → all sources queried (ambiguous message)."""
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains=set(),
+            calendar_client=calendar_client,
+            workflow_store=workflow_store,
+        )
+        # All snapshots populated (or at least attempted)
+        assert ctx.calendar_snapshot is not None
+        assert ctx.workflow_snapshot is not None
+        assert ctx.finance_snapshot is not None
+
+
+# --- ContextAssembler: timeouts ---------------------------------------------
+
+class TestAssemblerTimeouts:
+    @pytest.mark.asyncio
+    async def test_slow_calendar_times_out(self, proactive_store, settings_redis):
+        """Calendar source hangs → times out → None, other sources populated."""
+        slow_calendar = AsyncMock()
+
+        async def slow_list(*a, **kw):
+            await asyncio.sleep(10)  # way past timeout
+            return []
+
+        slow_calendar.list_events = slow_list
+        slow_calendar.is_free = AsyncMock(return_value=True)
+
+        asm = ContextAssembler(
+            proactive_store=proactive_store,
+            settings_redis=settings_redis,
+            source_timeout=0.1,  # very short
+        )
+        ctx = await asm.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"scheduling", "finance"},
+            calendar_client=slow_calendar,
+        )
+
+        assert ctx.calendar_snapshot is None  # timed out
+        assert ctx.finance_snapshot is not None  # other source still works
+
+    @pytest.mark.asyncio
+    async def test_slow_workflow_store_times_out(self, proactive_store, settings_redis):
+        slow_store = AsyncMock()
+
+        async def slow_list(*a, **kw):
+            await asyncio.sleep(10)
+            return []
+
+        slow_store.list_workflows = slow_list
+
+        asm = ContextAssembler(
+            proactive_store=proactive_store,
+            settings_redis=settings_redis,
+            source_timeout=0.1,
+        )
+        ctx = await asm.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"workflows"},
+            workflow_store=slow_store,
+        )
+        assert ctx.workflow_snapshot is None
+
+
+# --- ContextAssembler: error tolerance --------------------------------------
+
+class TestAssemblerErrorTolerance:
+    @pytest.mark.asyncio
+    async def test_calendar_error_yields_none(self, assembler):
+        broken_cal = AsyncMock()
+        broken_cal.list_events = AsyncMock(side_effect=ConnectionError("calendar down"))
+
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"scheduling"},
+            calendar_client=broken_cal,
+        )
+        assert ctx.calendar_snapshot is None
+
+    @pytest.mark.asyncio
+    async def test_workflow_store_error_yields_none(self, assembler):
+        broken_store = AsyncMock()
+        broken_store.list_workflows = AsyncMock(side_effect=RuntimeError("redis down"))
+
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains={"workflows"},
+            workflow_store=broken_store,
+        )
+        assert ctx.workflow_snapshot is None
+
+    @pytest.mark.asyncio
+    async def test_settings_redis_error_yields_defaults(self, proactive_store):
+        broken_redis = AsyncMock()
+        broken_redis.get = AsyncMock(side_effect=ConnectionError("redis down"))
+
+        asm = ContextAssembler(
+            proactive_store=proactive_store,
+            settings_redis=broken_redis,
+        )
+        ctx = await asm.assemble(CUSTOMER_ID, relevant_domains=set())
+        assert ctx.customer_preferences.tone == "professional"
+
+
+# --- ContextAssembler: delegation history -----------------------------------
+
+class TestAssemblerDelegationHistory:
+    @pytest.mark.asyncio
+    async def test_delegation_history_passed_through(self, assembler):
+        history = [
+            DelegationRecord(domain="finance", status="completed", timestamp="2026-03-21T09:00:00Z"),
+            DelegationRecord(domain="scheduling", status="completed", timestamp="2026-03-21T09:05:00Z"),
+        ]
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains=set(),
+            delegation_history=history,
+        )
+        assert len(ctx.delegation_history) == 2
+        assert ctx.delegation_history[0].domain == "finance"
+
+    @pytest.mark.asyncio
+    async def test_delegation_history_defaults_empty(self, assembler):
+        ctx = await assembler.assemble(CUSTOMER_ID, relevant_domains=set())
+        assert ctx.delegation_history == []
+
+
+# --- ContextAssembler: pending notifications --------------------------------
+
+class TestAssemblerNotifications:
+    @pytest.mark.asyncio
+    async def test_includes_pending_notifications(self, assembler, proactive_store):
+        from datetime import datetime, timezone
+        await proactive_store.add_pending_notification(CUSTOMER_ID, {
+            "domain": "finance",
+            "trigger_type": "finance_anomaly",
+            "priority": 3,
+            "title": "Unusual expense",
+            "message": "$5000 on marketing",
+        })
+        ctx = await assembler.assemble(
+            CUSTOMER_ID,
+            relevant_domains=set(),
+        )
+        assert len(ctx.pending_notifications) >= 1
+        assert ctx.pending_notifications[0]["domain"] == "finance"

--- a/tests/unit/test_scheduling_enhanced.py
+++ b/tests/unit/test_scheduling_enhanced.py
@@ -1,0 +1,404 @@
+"""
+Tests for scheduling specialist enhancements: preference learning.
+
+- Learned default duration from past meetings
+- Preferred hours influence slot ordering
+- Buffer awareness warns on tight transitions
+- Conflict details surfaced in create response
+- All enhancements degrade gracefully without interaction_context
+"""
+import pytest
+import fakeredis.aioredis
+from datetime import datetime, timedelta
+from dataclasses import dataclass, field as dc_field
+from typing import Any, Dict, List, Optional
+
+from src.agents.base.specialist import SpecialistTask, SpecialistStatus
+from src.agents.context import InteractionContext, CalendarSnapshot, CustomerPreferences
+from src.agents.executive_assistant import BusinessContext
+from src.agents.specialists.scheduling import (
+    SchedulingSpecialist,
+    CalendarEvent,
+    TimeSlot,
+)
+from src.proactive.state import ProactiveStateStore
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+CUSTOMER_ID = "cust_sched_test"
+FIXED_NOW = datetime(2026, 3, 21, 9, 0, 0)
+
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def store(fake_redis):
+    return ProactiveStateStore(fake_redis)
+
+
+@pytest.fixture
+def ctx():
+    return BusinessContext(
+        business_name="Sparkle & Shine",
+        industry="jewelry",
+        current_tools=["Google Calendar"],
+    )
+
+
+class FakeCalendar:
+    """In-memory calendar that returns predictable results."""
+
+    def __init__(self, events: Optional[List[CalendarEvent]] = None):
+        self._events = list(events or [])
+        self._created: List[CalendarEvent] = []
+        self._next_id = 100
+
+    async def list_events(self, start: datetime, end: datetime) -> List[CalendarEvent]:
+        return [e for e in self._events if e.start < end and e.end > start]
+
+    async def create_event(
+        self, title: str, start: datetime, end: datetime,
+        attendees: List[str], location: Optional[str] = None,
+    ) -> CalendarEvent:
+        evt = CalendarEvent(
+            id=f"evt_{self._next_id}",
+            title=title, start=start, end=end,
+            attendees=tuple(attendees), location=location,
+        )
+        self._next_id += 1
+        self._events.append(evt)
+        self._created.append(evt)
+        return evt
+
+    async def update_event(self, event_id, **kw):
+        pass
+
+    async def delete_event(self, event_id):
+        pass
+
+    async def is_free(self, start: datetime, end: datetime) -> bool:
+        overlaps = [e for e in self._events if e.start < end and e.end > start]
+        return len(overlaps) == 0
+
+    async def find_slots(
+        self, duration: timedelta, window_start: datetime, window_end: datetime,
+    ) -> List[TimeSlot]:
+        # Simple implementation: return slots at 9am, 10am, 14am, 15pm, 16pm
+        slots = []
+        for h in [9, 10, 14, 15, 16]:
+            s = window_start.replace(hour=h, minute=0, second=0)
+            e = s + duration
+            if s >= window_start and e <= window_end:
+                busy = any(ev.start < e and ev.end > s for ev in self._events)
+                if not busy:
+                    slots.append(TimeSlot(start=s, end=e))
+        return slots
+
+
+def _task(description, ctx, *, interaction_context=None, memories=None):
+    return SpecialistTask(
+        description=description,
+        customer_id=CUSTOMER_ID,
+        business_context=ctx,
+        domain_memories=memories or [],
+        interaction_context=interaction_context,
+    )
+
+
+# --- ProactiveStateStore: scheduling preference methods ---------------------
+
+class TestSchedulingPreferenceStorage:
+    @pytest.mark.asyncio
+    async def test_record_and_get_preferred_duration(self, store):
+        """Record several durations, get back the most common one."""
+        for _ in range(3):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 10)
+        await store.record_scheduling_preference(CUSTOMER_ID, 60, 14)
+
+        result = await store.get_preferred_duration(CUSTOMER_ID)
+        assert result == 30  # mode: 30 appears 3x vs 60 1x
+
+    @pytest.mark.asyncio
+    async def test_preferred_duration_none_when_empty(self, store):
+        result = await store.get_preferred_duration(CUSTOMER_ID)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_preferred_hours(self, store):
+        """Hours ranked by frequency."""
+        for _ in range(3):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 10)
+        for _ in range(5):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 14)
+        await store.record_scheduling_preference(CUSTOMER_ID, 30, 9)
+
+        hours = await store.get_preferred_hours(CUSTOMER_ID)
+        assert hours[0] == 14  # most frequent first
+        assert 10 in hours
+        assert 9 in hours
+
+    @pytest.mark.asyncio
+    async def test_preferred_hours_empty(self, store):
+        hours = await store.get_preferred_hours(CUSTOMER_ID)
+        assert hours == []
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_buffer_minutes(self, store):
+        await store.set_buffer_minutes(CUSTOMER_ID, 15)
+        result = await store.get_buffer_minutes(CUSTOMER_ID)
+        assert result == 15
+
+    @pytest.mark.asyncio
+    async def test_buffer_minutes_default(self, store):
+        result = await store.get_buffer_minutes(CUSTOMER_ID)
+        assert result == 0  # default: no buffer
+
+
+# --- Create: learned duration -----------------------------------------------
+
+class TestLearnedDuration:
+    @pytest.mark.asyncio
+    async def test_uses_learned_duration_when_no_explicit(self, store, ctx):
+        """When user doesn't say duration and we have learned data, use it."""
+        # Build preference: most meetings are 30m
+        for _ in range(4):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 10)
+
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(
+                preferred_meeting_duration=30,
+            ),
+        )
+
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        created = cal._created[0]
+        duration_min = (created.end - created.start).total_seconds() / 60
+        assert duration_min == 30
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_60m_without_context(self, ctx):
+        """No interaction_context → 60m default."""
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        created = cal._created[0]
+        duration_min = (created.end - created.start).total_seconds() / 60
+        assert duration_min == 60
+
+    @pytest.mark.asyncio
+    async def test_explicit_duration_overrides_learned(self, store, ctx):
+        """'for 45 minutes' always wins over learned preference."""
+        for _ in range(4):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 10)
+
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(
+                preferred_meeting_duration=30,
+            ),
+        )
+
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task(
+            "schedule a meeting with John at 2pm for 45 minutes",
+            ctx, interaction_context=ic,
+        )
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        created = cal._created[0]
+        duration_min = (created.end - created.start).total_seconds() / 60
+        assert duration_min == 45
+
+
+# --- Create: records preference after booking --------------------------------
+
+class TestPreferenceRecording:
+    @pytest.mark.asyncio
+    async def test_records_duration_and_hour_after_create(self, store, ctx):
+        """After a successful create, the duration and hour are recorded."""
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("schedule a meeting with John at 2pm for 30 minutes", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+
+        # Verify preferences were recorded
+        pref_dur = await store.get_preferred_duration(CUSTOMER_ID)
+        # Only 1 sample — should still return it
+        assert pref_dur == 30
+
+        hours = await store.get_preferred_hours(CUSTOMER_ID)
+        assert 14 in hours  # 2pm = hour 14
+
+
+# --- Create: buffer warning -------------------------------------------------
+
+class TestBufferWarning:
+    @pytest.mark.asyncio
+    async def test_warns_on_tight_transition(self, store, ctx):
+        """When next event starts within buffer_minutes, summary warns."""
+        await store.set_buffer_minutes(CUSTOMER_ID, 15)
+
+        # Existing event at 3pm
+        existing = CalendarEvent(
+            id="evt_1", title="Team Standup",
+            start=FIXED_NOW.replace(hour=15, minute=0),
+            end=FIXED_NOW.replace(hour=15, minute=30),
+        )
+        cal = FakeCalendar(events=[existing])
+
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(buffer_minutes=15),
+            calendar_snapshot=CalendarSnapshot(
+                events_next_24h=[{
+                    "title": "Team Standup",
+                    "start": existing.start.isoformat(),
+                    "end": existing.end.isoformat(),
+                }],
+            ),
+        )
+
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        # Book at 2pm for 60m → ends at 3pm, which is exactly when Team Standup starts
+        task = _task("schedule a meeting with John at 2pm", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        summary_lower = result.summary_for_ea.lower()
+        assert "tight" in summary_lower or "buffer" in summary_lower or "back-to-back" in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_no_buffer_warning_with_space(self, store, ctx):
+        """Plenty of time before next event → no warning."""
+        await store.set_buffer_minutes(CUSTOMER_ID, 15)
+
+        # Existing event at 5pm — plenty of gap after 2pm meeting
+        existing = CalendarEvent(
+            id="evt_1", title="Team Standup",
+            start=FIXED_NOW.replace(hour=17, minute=0),
+            end=FIXED_NOW.replace(hour=17, minute=30),
+        )
+        cal = FakeCalendar(events=[existing])
+
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(buffer_minutes=15),
+            calendar_snapshot=CalendarSnapshot(
+                events_next_24h=[{
+                    "title": "Team Standup",
+                    "start": existing.start.isoformat(),
+                    "end": existing.end.isoformat(),
+                }],
+            ),
+        )
+
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        summary_lower = result.summary_for_ea.lower()
+        assert "tight" not in summary_lower and "buffer" not in summary_lower and "back-to-back" not in summary_lower
+
+
+# --- Slot find: preferred hours ranking -------------------------------------
+
+class TestSlotPreferredHours:
+    @pytest.mark.asyncio
+    async def test_slots_sorted_by_preferred_hours(self, store, ctx):
+        """When preferred hours available, slots near those hours come first."""
+        # Prefer 2pm (14h) meetings
+        for _ in range(5):
+            await store.record_scheduling_preference(CUSTOMER_ID, 30, 14)
+
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(
+                preferred_hours=[14, 15],
+            ),
+        )
+
+        cal = FakeCalendar()  # will return slots at 9, 10, 14, 15, 16
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("find me 30 minutes this week", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        slots = result.payload["slots"]
+        assert len(slots) > 0
+        # First slot should be at 14:00 (preferred) rather than 9:00
+        first_start = slots[0]["start"]
+        assert "T14:00" in first_start
+
+    @pytest.mark.asyncio
+    async def test_slot_order_unchanged_without_preferences(self, ctx):
+        """No preferences → original order (earliest first)."""
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW,
+        )
+        task = _task("find me 30 minutes this week", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        slots = result.payload["slots"]
+        if len(slots) >= 2:
+            # Should be in chronological order (9am first)
+            assert slots[0]["start"] <= slots[1]["start"]
+
+
+# --- Graceful degradation ---------------------------------------------------
+
+class TestSchedulingGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_create_works_without_proactive_store(self, ctx):
+        """No proactive_state → no preference recording, no crash."""
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert len(cal._created) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_works_without_interaction_context(self, store, ctx):
+        """proactive_state present but no interaction_context → still works."""
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        duration_min = (cal._created[0].end - cal._created[0].start).total_seconds() / 60
+        assert duration_min == 60  # default

--- a/tests/unit/test_scheduling_enhanced.py
+++ b/tests/unit/test_scheduling_enhanced.py
@@ -288,8 +288,9 @@ class TestBufferWarning:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        summary_lower = result.summary_for_ea.lower()
-        assert "tight" in summary_lower or "buffer" in summary_lower or "back-to-back" in summary_lower
+        assert "back-to-back" in result.summary_for_ea.lower()
+        # Should name the conflicting event
+        assert "team standup" in result.summary_for_ea.lower()
 
     @pytest.mark.asyncio
     async def test_no_buffer_warning_with_space(self, store, ctx):
@@ -322,8 +323,28 @@ class TestBufferWarning:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        summary_lower = result.summary_for_ea.lower()
-        assert "tight" not in summary_lower and "buffer" not in summary_lower and "back-to-back" not in summary_lower
+        assert "back-to-back" not in result.summary_for_ea.lower()
+
+    @pytest.mark.asyncio
+    async def test_buffer_note_with_malformed_snapshot_event(self, store, ctx):
+        """Calendar snapshot has event with unparseable start → no crash, no warning."""
+        await store.set_buffer_minutes(CUSTOMER_ID, 15)
+
+        cal = FakeCalendar()
+        ic = InteractionContext(
+            customer_preferences=CustomerPreferences(buffer_minutes=15),
+            calendar_snapshot=CalendarSnapshot(
+                events_next_24h=[{"title": "Garbage", "start": "not-a-date"}],
+            ),
+        )
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=store,
+        )
+        task = _task("schedule a meeting with John at 2pm", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "back-to-back" not in result.summary_for_ea.lower()
 
 
 # --- Slot find: preferred hours ranking -------------------------------------
@@ -368,12 +389,37 @@ class TestSlotPreferredHours:
 
         assert result.status == SpecialistStatus.COMPLETED
         slots = result.payload["slots"]
-        if len(slots) >= 2:
-            # Should be in chronological order (9am first)
-            assert slots[0]["start"] <= slots[1]["start"]
+        assert len(slots) >= 2, "FakeCalendar should return multiple slots"
+        # Chronological: 9am before 10am
+        assert slots[0]["start"] < slots[1]["start"]
+        assert "T09:00" in slots[0]["start"]
 
 
 # --- Graceful degradation ---------------------------------------------------
+
+class TestPreferenceRecordingFailure:
+    @pytest.mark.asyncio
+    async def test_recording_failure_does_not_break_create(self, ctx):
+        """ProactiveStateStore raises during recording → event still created."""
+        from unittest.mock import AsyncMock
+        broken_store = AsyncMock()
+        broken_store.record_scheduling_preference = AsyncMock(
+            side_effect=ConnectionError("redis down"),
+        )
+        # add_domain_event needed for _maybe_stage_conflict
+        broken_store.add_domain_event = AsyncMock()
+
+        cal = FakeCalendar()
+        specialist = SchedulingSpecialist(
+            calendar=cal, clock=lambda: FIXED_NOW, proactive_state=broken_store,
+        )
+        task = _task("schedule a meeting with John at 2pm for 30 minutes", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert len(cal._created) == 1
+        assert "Booked" in result.summary_for_ea
+
 
 class TestSchedulingGracefulDegradation:
     @pytest.mark.asyncio

--- a/tests/unit/test_specialist_base.py
+++ b/tests/unit/test_specialist_base.py
@@ -100,6 +100,34 @@ class TestSpecialistTask:
         )
         assert len(task.prior_turns) == 2
 
+    def test_interaction_context_defaults_to_none(self, ctx):
+        """Existing construction without interaction_context still works."""
+        task = SpecialistTask(
+            description="check engagement",
+            customer_id="cust_abc",
+            business_context=ctx,
+            domain_memories=[],
+        )
+        assert task.interaction_context is None
+
+    def test_interaction_context_round_trips(self, ctx):
+        """New field carries the assembled context through to the specialist."""
+        from src.agents.context import InteractionContext, CustomerPreferences
+        ic = InteractionContext(
+            recent_conversation_summary="Talked about budgets.",
+            customer_preferences=CustomerPreferences(tone="friendly"),
+        )
+        task = SpecialistTask(
+            description="track $500 expense",
+            customer_id="cust_abc",
+            business_context=ctx,
+            domain_memories=[],
+            interaction_context=ic,
+        )
+        assert task.interaction_context is not None
+        assert task.interaction_context.customer_preferences.tone == "friendly"
+        assert task.interaction_context.recent_conversation_summary == "Talked about budgets."
+
 
 # --- SpecialistResult -------------------------------------------------------
 

--- a/tests/unit/test_specialist_personality.py
+++ b/tests/unit/test_specialist_personality.py
@@ -121,26 +121,30 @@ class TestNoLLMToneFormatting:
         wordy = SpecialistResult(
             status=SpecialistStatus.COMPLETED, domain="finance",
             payload={"amount": 500}, confidence=0.85,
-            summary_for_ea="Tracked $500.00 → Acme Corp (category: marketing).",
+            summary_for_ea="I can see that you tracked $500.00 to Acme Corp.",
         )
         result = await ea._synthesize_specialist_result(wordy, context)
-        # Concise should be short — no extra framing added
-        assert len(result) <= len(wordy.summary_for_ea)
+        # Concise should strip "I can see that" preamble
+        assert not result.lower().startswith("i can see")
+        assert "$500" in result
 
     @pytest.mark.asyncio
     async def test_friendly_adds_casual_framing(self, ea, sample_result, context):
         ea._personality = {"tone": "friendly", "language": "en", "name": "Aria"}
         result = await ea._synthesize_specialist_result(sample_result, context)
-        # Friendly wraps with casual framing — should differ from raw summary
-        assert result != sample_result.summary_for_ea
+        # Friendly prepends "All done!"
+        assert result.startswith("All done!")
+        assert sample_result.summary_for_ea in result
 
     @pytest.mark.asyncio
     async def test_detailed_includes_payload(self, ea, sample_result, context):
         ea._personality = {"tone": "detailed", "language": "en", "name": "Aria"}
         result = await ea._synthesize_specialist_result(sample_result, context)
-        # Detailed should include structured payload info
-        assert "marketing" in result
-        assert "Acme" in result.replace("Acme Corp", "Acme")  # from payload or summary
+        # Detailed appends "Details:" section from payload
+        assert "Details:" in result
+        # Payload keys should be unpacked (amount, vendor, category)
+        assert "500" in result
+        assert "Acme Corp" in result
 
     @pytest.mark.asyncio
     async def test_four_tones_produce_different_outputs(self, ea, sample_result, context):

--- a/tests/unit/test_specialist_personality.py
+++ b/tests/unit/test_specialist_personality.py
@@ -1,0 +1,174 @@
+"""
+Tests for personality-aware response synthesis.
+
+The EA's _synthesize_specialist_result must respect the customer's tone
+setting. The LLM path injects _TONE_GUIDANCE into the prompt; the no-LLM
+path applies tone-aware formatting to the specialist's summary_for_ea.
+
+Four tones must produce meaningfully different outputs for the same
+specialist result.
+"""
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.agents.base.specialist import SpecialistResult, SpecialistStatus
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+@pytest.fixture
+def ea():
+    with patch("src.agents.executive_assistant.ExecutiveAssistantMemory") as MockMem, \
+         patch("src.agents.executive_assistant.WorkflowCreator"), \
+         patch("src.agents.executive_assistant.ChatOpenAI"):
+        from src.agents.executive_assistant import ExecutiveAssistant, BusinessContext
+
+        mem = MockMem.return_value
+        mem.get_business_context = AsyncMock(return_value=BusinessContext(
+            business_name="Test Co",
+        ))
+        mem.search_business_knowledge = AsyncMock(return_value=[])
+        mem.store_conversation_context = AsyncMock()
+        mem.get_conversation_context = AsyncMock(return_value={})
+        mem.store_business_context = AsyncMock()
+
+        instance = ExecutiveAssistant(customer_id="cust_tone")
+        instance.llm = None
+        yield instance
+
+
+@pytest.fixture
+def sample_result():
+    """A finance specialist result used across all tone tests."""
+    return SpecialistResult(
+        status=SpecialistStatus.COMPLETED,
+        domain="finance",
+        payload={"amount": 500.0, "vendor": "Acme Corp", "category": "marketing"},
+        confidence=0.85,
+        summary_for_ea="Tracked $500.00 → Acme Corp (category: marketing).",
+    )
+
+
+@pytest.fixture
+def context():
+    from src.agents.executive_assistant import BusinessContext
+    return BusinessContext(business_name="Sparkle & Shine")
+
+
+# --- LLM path: prompt includes tone guidance --------------------------------
+
+class TestLLMSynthesisToneGuidance:
+    """When an LLM is available, the synthesis prompt must include the
+    matching _TONE_GUIDANCE string for the configured tone."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tone,expected_fragment", [
+        ("professional", "warm, professional"),
+        ("friendly", "casual and friendly"),
+        ("concise", "brief"),
+        ("detailed", "thorough"),
+    ])
+    async def test_llm_prompt_includes_tone_guidance(
+        self, ea, sample_result, context, tone, expected_fragment,
+    ):
+        from src.agents.executive_assistant import _TONE_GUIDANCE
+
+        ea._personality = {"tone": tone, "language": "en", "name": "Aria"}
+
+        llm = AsyncMock()
+        llm.ainvoke = AsyncMock(return_value=MagicMock(content="relayed"))
+        ea.llm = llm
+
+        await ea._synthesize_specialist_result(sample_result, context)
+
+        prompt = llm.ainvoke.call_args.args[0][0].content
+        assert expected_fragment in prompt.lower(), (
+            f"Tone '{tone}' guidance not found in prompt: {prompt[:200]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_llm_prompt_uses_personality_name(self, ea, sample_result, context):
+        ea._personality = {"tone": "friendly", "language": "en", "name": "Beacon"}
+
+        llm = AsyncMock()
+        llm.ainvoke = AsyncMock(return_value=MagicMock(content="ok"))
+        ea.llm = llm
+
+        await ea._synthesize_specialist_result(sample_result, context)
+
+        prompt = llm.ainvoke.call_args.args[0][0].content
+        assert "Beacon" in prompt
+        assert "Sarah" not in prompt
+
+
+# --- No-LLM path: tone-aware formatting ------------------------------------
+
+class TestNoLLMToneFormatting:
+    """Without an LLM, the EA formats the specialist's summary_for_ea
+    differently based on tone. Each tone must produce distinct output."""
+
+    @pytest.mark.asyncio
+    async def test_professional_returns_summary_as_is(self, ea, sample_result, context):
+        ea._personality = {"tone": "professional", "language": "en", "name": "Aria"}
+        result = await ea._synthesize_specialist_result(sample_result, context)
+        assert result == sample_result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_concise_strips_preamble(self, ea, context):
+        ea._personality = {"tone": "concise", "language": "en", "name": "Aria"}
+        wordy = SpecialistResult(
+            status=SpecialistStatus.COMPLETED, domain="finance",
+            payload={"amount": 500}, confidence=0.85,
+            summary_for_ea="Tracked $500.00 → Acme Corp (category: marketing).",
+        )
+        result = await ea._synthesize_specialist_result(wordy, context)
+        # Concise should be short — no extra framing added
+        assert len(result) <= len(wordy.summary_for_ea)
+
+    @pytest.mark.asyncio
+    async def test_friendly_adds_casual_framing(self, ea, sample_result, context):
+        ea._personality = {"tone": "friendly", "language": "en", "name": "Aria"}
+        result = await ea._synthesize_specialist_result(sample_result, context)
+        # Friendly wraps with casual framing — should differ from raw summary
+        assert result != sample_result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_detailed_includes_payload(self, ea, sample_result, context):
+        ea._personality = {"tone": "detailed", "language": "en", "name": "Aria"}
+        result = await ea._synthesize_specialist_result(sample_result, context)
+        # Detailed should include structured payload info
+        assert "marketing" in result
+        assert "Acme" in result.replace("Acme Corp", "Acme")  # from payload or summary
+
+    @pytest.mark.asyncio
+    async def test_four_tones_produce_different_outputs(self, ea, sample_result, context):
+        outputs = {}
+        for tone in ("professional", "friendly", "concise", "detailed"):
+            ea._personality = {"tone": tone, "language": "en", "name": "Aria"}
+            outputs[tone] = await ea._synthesize_specialist_result(sample_result, context)
+
+        # At least 3 of the 4 must be distinct (professional/concise could overlap
+        # for very short summaries, but friendly and detailed should always differ).
+        unique = set(outputs.values())
+        assert len(unique) >= 3, f"Expected >=3 distinct outputs, got {len(unique)}: {outputs}"
+
+    @pytest.mark.asyncio
+    async def test_unknown_tone_falls_back_to_professional(self, ea, sample_result, context):
+        ea._personality = {"tone": "nonexistent", "language": "en", "name": "Aria"}
+        result = await ea._synthesize_specialist_result(sample_result, context)
+        # Should not crash — falls back to professional (as-is)
+        assert result == sample_result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_no_summary_fallback_includes_payload(self, ea, context):
+        """When summary_for_ea is None, the fallback must still work."""
+        bare = SpecialistResult(
+            status=SpecialistStatus.COMPLETED, domain="finance",
+            payload={"amount": 42}, confidence=0.8,
+            summary_for_ea=None,
+        )
+        ea._personality = {"tone": "professional", "language": "en", "name": "Aria"}
+        result = await ea._synthesize_specialist_result(bare, context)
+        assert "42" in result  # payload should be visible in fallback

--- a/tests/unit/test_workflow_enhanced.py
+++ b/tests/unit/test_workflow_enhanced.py
@@ -1,0 +1,300 @@
+"""
+Tests for workflow specialist enhancements: contextual suggestions.
+
+- List includes failure context from interaction_context
+- Deploy suggests related workflows from catalog
+- Suggestion respects cooldown
+- Topic counting in ProactiveStateStore
+- Usage-based suggestion at threshold
+- Graceful degradation without context
+"""
+import pytest
+import fakeredis.aioredis
+from unittest.mock import AsyncMock
+
+from src.agents.base.specialist import SpecialistTask, SpecialistStatus
+from src.agents.context import InteractionContext, WorkflowSnapshot, CustomerPreferences
+from src.agents.executive_assistant import BusinessContext
+from src.agents.specialists.workflows import WorkflowSpecialist
+from src.proactive.state import ProactiveStateStore
+from src.workflows.store import WorkflowStore
+from src.workflows.catalog import WorkflowTemplate
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+CUSTOMER_ID = "cust_wf_test"
+
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def proactive_store(fake_redis):
+    return ProactiveStateStore(fake_redis)
+
+
+@pytest.fixture
+def ctx():
+    return BusinessContext(
+        business_name="Acme Corp",
+        industry="saas",
+        current_tools=["HubSpot", "Slack", "n8n"],
+    )
+
+
+@pytest.fixture
+def wf_redis():
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def store(wf_redis):
+    return WorkflowStore(wf_redis)
+
+
+@pytest.fixture
+def n8n_client():
+    m = AsyncMock()
+    m.create_workflow = AsyncMock(return_value={"id": "wf_new", "name": "Created"})
+    m.activate_workflow = AsyncMock()
+    m.deactivate_workflow = AsyncMock()
+    m.delete_workflow = AsyncMock()
+    return m
+
+
+_HUBSPOT_TEMPLATE = WorkflowTemplate(
+    id="hubspot_weekly",
+    name="HubSpot Weekly Report",
+    description="Email HubSpot pipeline on schedule",
+    integrations=["hubspot", "email"],
+    category="reporting",
+    tags=["weekly", "report", "pipeline"],
+    raw={
+        "name": "HubSpot Weekly Report",
+        "nodes": [
+            {"id": "t", "name": "Trigger",
+             "type": "n8n-nodes-base.scheduleTrigger",
+             "typeVersion": 1.2, "position": [0, 0],
+             "parameters": {"rule": {"interval": [
+                 {"field": "cronExpression",
+                  "expression": "{{CONFIGURE: cron schedule}}"}]}}},
+            {"id": "e", "name": "Email",
+             "type": "n8n-nodes-base.emailSend",
+             "typeVersion": 2.1, "position": [200, 0],
+             "parameters": {"toEmail": "{{CONFIGURE: recipient email}}"}},
+        ],
+        "connections": {
+            "Trigger": {"main": [[{"node": "Email", "type": "main", "index": 0}]]},
+        },
+        "active": False, "settings": {},
+    },
+    source="local",
+)
+
+_SLACK_TEMPLATE = WorkflowTemplate(
+    id="slack_alerts",
+    name="Slack Alert Pipeline",
+    description="Send alerts to Slack channel on events",
+    integrations=["slack"],
+    category="notifications",
+    tags=["alert", "slack", "notification"],
+    raw={
+        "name": "Slack Alert Pipeline",
+        "nodes": [],
+        "connections": {},
+        "active": False, "settings": {},
+    },
+    source="local",
+)
+
+
+@pytest.fixture
+def catalog():
+    m = AsyncMock()
+    m.search_local = lambda q: (
+        [_HUBSPOT_TEMPLATE]
+        if any(k in q.lower() for k in ("hubspot", "pipeline", "report"))
+        else [_SLACK_TEMPLATE]
+        if any(k in q.lower() for k in ("slack", "alert"))
+        else []
+    )
+    m.list_local = lambda: [_HUBSPOT_TEMPLATE, _SLACK_TEMPLATE]
+    m.search_community = AsyncMock(return_value=[])
+    return m
+
+
+@pytest.fixture
+async def specialist(store, n8n_client, catalog, proactive_store):
+    await store.set_config(CUSTOMER_ID, base_url="http://n8n.test", api_key="k")
+    return WorkflowSpecialist(
+        store=store,
+        catalog=catalog,
+        n8n_client_factory=lambda base_url, api_key: n8n_client,
+        proactive_state=proactive_store,
+    )
+
+
+def _task(desc, ctx, *, interaction_context=None, prior_turns=None):
+    return SpecialistTask(
+        description=desc,
+        customer_id=CUSTOMER_ID,
+        business_context=ctx,
+        domain_memories=[],
+        prior_turns=prior_turns or [],
+        interaction_context=interaction_context,
+    )
+
+
+# --- ProactiveStateStore: topic tracking ------------------------------------
+
+class TestTopicCounting:
+    @pytest.mark.asyncio
+    async def test_increment_and_get_topic_counts(self, proactive_store):
+        await proactive_store.increment_topic_count(CUSTOMER_ID, "reporting")
+        await proactive_store.increment_topic_count(CUSTOMER_ID, "reporting")
+        await proactive_store.increment_topic_count(CUSTOMER_ID, "alerts")
+
+        counts = await proactive_store.get_topic_counts(CUSTOMER_ID)
+        assert counts["reporting"] == 2
+        assert counts["alerts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_topic_counts(self, proactive_store):
+        counts = await proactive_store.get_topic_counts(CUSTOMER_ID)
+        assert counts == {}
+
+
+# --- List: failure context ---------------------------------------------------
+
+class TestListFailureContext:
+    @pytest.mark.asyncio
+    async def test_list_includes_failure_context(self, specialist, store, ctx):
+        """When workflow_snapshot has recent_failures, list summary mentions them."""
+        await store.add_workflow(CUSTOMER_ID, "wf1", "Monday Report", "active")
+
+        ic = InteractionContext(
+            workflow_snapshot=WorkflowSnapshot(
+                active_count=1,
+                workflow_names=["Monday Report"],
+                recent_failures=[
+                    {"name": "Monday Report", "error": "SMTP timeout", "timestamp": "2026-03-20T08:00:00"},
+                ],
+            ),
+        )
+
+        task = _task("what automations do I have?", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        summary_lower = result.summary_for_ea.lower()
+        assert "fail" in summary_lower or "error" in summary_lower or "issue" in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_list_no_failure_mention_when_clean(self, specialist, store, ctx):
+        """No failures → no failure mention."""
+        await store.add_workflow(CUSTOMER_ID, "wf1", "Monday Report", "active")
+
+        ic = InteractionContext(
+            workflow_snapshot=WorkflowSnapshot(
+                active_count=1,
+                workflow_names=["Monday Report"],
+                recent_failures=[],
+            ),
+        )
+
+        task = _task("what automations do I have?", ctx, interaction_context=ic)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        summary_lower = result.summary_for_ea.lower()
+        assert "fail" not in summary_lower and "error" not in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_list_works_without_context(self, specialist, store, ctx):
+        """No interaction_context → existing behavior."""
+        await store.add_workflow(CUSTOMER_ID, "wf1", "Monday Report", "active")
+
+        task = _task("what automations do I have?", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "Monday Report" in result.summary_for_ea
+
+
+# --- Deploy: related suggestions --------------------------------------------
+
+class TestDeploySuggestions:
+    @pytest.mark.asyncio
+    async def test_deploy_suggests_related_template(self, specialist, ctx, proactive_store):
+        """After deploying a report workflow, suggest the related alert workflow."""
+        task = _task(
+            "send me my HubSpot pipeline every Monday at 9am to user@example.com",
+            ctx,
+        )
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        # The suggestion should mention the related template
+        summary_lower = result.summary_for_ea.lower()
+        # Should mention the deployed workflow and potentially suggest another
+        assert "deployed" in summary_lower or "active" in summary_lower
+
+    @pytest.mark.asyncio
+    async def test_suggestion_respects_cooldown(self, specialist, ctx, proactive_store):
+        """If we already suggested a template recently, don't suggest again."""
+        # Pre-set cooldown for the slack template
+        await proactive_store.record_cooldown(
+            CUSTOMER_ID, "wf_suggest:slack_alerts", 86400,
+        )
+
+        task = _task(
+            "send me my HubSpot pipeline every Monday at 9am to user@example.com",
+            ctx,
+        )
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        # Should NOT suggest the Slack template since it's cooling down
+        assert "slack alert" not in result.summary_for_ea.lower()
+
+
+# --- Graceful degradation ---------------------------------------------------
+
+class TestWorkflowGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_list_works_without_proactive_state(self, store, n8n_client, catalog, ctx):
+        """No proactive_state → list still works."""
+        await store.set_config(CUSTOMER_ID, base_url="http://n8n.test", api_key="k")
+        await store.add_workflow(CUSTOMER_ID, "wf1", "Monday Report", "active")
+
+        specialist = WorkflowSpecialist(
+            store=store,
+            catalog=catalog,
+            n8n_client_factory=lambda base_url, api_key: n8n_client,
+        )
+        task = _task("what automations do I have?", ctx)
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        assert "Monday Report" in result.summary_for_ea
+
+    @pytest.mark.asyncio
+    async def test_deploy_without_proactive_state(self, store, n8n_client, catalog, ctx):
+        """No proactive_state → deploy still works, no suggestion crash."""
+        await store.set_config(CUSTOMER_ID, base_url="http://n8n.test", api_key="k")
+
+        specialist = WorkflowSpecialist(
+            store=store,
+            catalog=catalog,
+            n8n_client_factory=lambda base_url, api_key: n8n_client,
+        )
+        task = _task(
+            "send me my HubSpot pipeline every Monday at 9am to user@example.com",
+            ctx,
+        )
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED

--- a/tests/unit/test_workflow_enhanced.py
+++ b/tests/unit/test_workflow_enhanced.py
@@ -100,7 +100,7 @@ _SLACK_TEMPLATE = WorkflowTemplate(
     description="Send alerts to Slack channel on events",
     integrations=["slack"],
     category="notifications",
-    tags=["alert", "slack", "notification"],
+    tags=["alert", "slack", "notification", "report"],
     raw={
         "name": "Slack Alert Pipeline",
         "nodes": [],
@@ -189,8 +189,9 @@ class TestListFailureContext:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        summary_lower = result.summary_for_ea.lower()
-        assert "fail" in summary_lower or "error" in summary_lower or "issue" in summary_lower
+        # _failure_note produces "Heads up: recent issues with {names}."
+        assert "recent issues" in result.summary_for_ea.lower()
+        assert "Monday Report" in result.summary_for_ea
 
     @pytest.mark.asyncio
     async def test_list_no_failure_mention_when_clean(self, specialist, store, ctx):
@@ -237,10 +238,26 @@ class TestDeploySuggestions:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        # The suggestion should mention the related template
-        summary_lower = result.summary_for_ea.lower()
-        # Should mention the deployed workflow and potentially suggest another
-        assert "deployed" in summary_lower or "active" in summary_lower
+        # Must contain both: deployment confirmation AND related suggestion
+        assert "deployed and active" in result.summary_for_ea.lower()
+        assert "you might also like" in result.summary_for_ea.lower()
+
+    @pytest.mark.asyncio
+    async def test_deploy_records_cooldown_after_suggestion(self, specialist, ctx, proactive_store):
+        """After suggesting a related template, cooldown is recorded."""
+        task = _task(
+            "send me my HubSpot pipeline every Monday at 9am to user@example.com",
+            ctx,
+        )
+        await specialist.execute_task(task)
+
+        # The suggested template should now be cooling down
+        # HubSpot template shares "report"/"weekly" tags — one of the other templates
+        # got suggested; check that its cooldown key was set
+        is_cooling = await proactive_store.is_cooling_down(
+            CUSTOMER_ID, "wf_suggest:slack_alerts",
+        )
+        assert is_cooling
 
     @pytest.mark.asyncio
     async def test_suggestion_respects_cooldown(self, specialist, ctx, proactive_store):
@@ -257,11 +274,42 @@ class TestDeploySuggestions:
         result = await specialist.execute_task(task)
 
         assert result.status == SpecialistStatus.COMPLETED
-        # Should NOT suggest the Slack template since it's cooling down
-        assert "slack alert" not in result.summary_for_ea.lower()
+        # Should NOT suggest — all other templates are cooling down
+        assert "you might also like" not in result.summary_for_ea.lower()
 
 
 # --- Graceful degradation ---------------------------------------------------
+
+class TestSuggestionError:
+    @pytest.mark.asyncio
+    async def test_catalog_error_in_suggest_does_not_crash_deploy(
+        self, store, n8n_client, proactive_store, ctx,
+    ):
+        """If catalog.list_local() raises during suggestion, deploy still succeeds."""
+        await store.set_config(CUSTOMER_ID, base_url="http://n8n.test", api_key="k")
+
+        broken_catalog = AsyncMock()
+        broken_catalog.search_local = lambda q: [_HUBSPOT_TEMPLATE]
+        broken_catalog.list_local = lambda: (_ for _ in ()).throw(RuntimeError("catalog broken"))
+        broken_catalog.search_community = AsyncMock(return_value=[])
+
+        specialist = WorkflowSpecialist(
+            store=store,
+            catalog=broken_catalog,
+            n8n_client_factory=lambda base_url, api_key: n8n_client,
+            proactive_state=proactive_store,
+        )
+        task = _task(
+            "send me my HubSpot pipeline every Monday at 9am to user@example.com",
+            ctx,
+        )
+        result = await specialist.execute_task(task)
+
+        assert result.status == SpecialistStatus.COMPLETED
+        # Deploy succeeded but no suggestion (error swallowed)
+        assert "deployed and active" in result.summary_for_ea.lower()
+        assert "you might also like" not in result.summary_for_ea.lower()
+
 
 class TestWorkflowGracefulDegradation:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Specialists currently work in isolation — the finance specialist doesn't know about a 3pm meeting, the scheduling specialist doesn't know a large expense just landed. This PR gives every specialist a shared, read-only `InteractionContext` assembled once per interaction, and uses it to make each specialist context-aware.

### Commits (8)

1. **Context layer** — `InteractionContext` dataclass, `ContextAssembler` with concurrent per-source fetches and independent timeouts
2. **SpecialistTask field** — `interaction_context: Optional[InteractionContext]` added to the specialist input contract
3. **Personality** — tone-aware response synthesis at the EA level (concise/friendly/detailed/professional)
4. **EA wiring** — `ContextAssembler` integrated into the delegation pipeline
5. **Finance** — deviation notes (>2x baseline warning), budget tracking, baseline comparison via `_enrichment_notes`
6. **Scheduling** — preference learning (learned duration, preferred hours, buffer-minutes awareness via `_buffer_note`)
7. **Workflows** — failure context in list view (`_failure_note`), related template suggestions with cooldowns (`_suggest_related`), topic counting
8. **Test + docs audit** — strengthened assertions, added edge-case tests, fixed fixtures, added docstrings across all touched files

### Key design decisions

- **Personality lives in the EA, not specialists.** Specialists produce structured data; the EA owns the customer-facing voice. One synthesis point = consistent tone across domains.
- **ContextAssembler uses per-source timeouts.** A slow Redis or broken calendar client degrades to `None` in the snapshot — never blocks the customer's response.
- **Lazy domain loading.** If the EA knows the message is about scheduling, finance/workflow fetches are never launched. Empty `relevant_domains` = fetch all (ambiguous intent).
- **SpecialistTask is the only input channel.** Specialists never get Redis handles, settings access, or LLM clients. The isolation boundary is preserved.

## Honest assessment

### What works well
- The context layer is clean — frozen dataclasses, concurrent fetches, independent timeouts, graceful degradation
- Personality synthesis is correctly centralized at the EA
- Test coverage is solid: 84 tests across 6 new/modified test files, all passing
- The specialist isolation contract held — no framework changes needed for any enhancement

### What's rough
- **Workflow suggestion logic has first-match bias.** `_suggest_related` returns the first template with any tag/integration overlap, not the best match. Overlap quality is binary — a generic shared tag like "report" triggers a suggestion even if the templates are functionally unrelated.
- **Cooldown is per-template, not per-slot.** If template A is cooling down, the loop suggests template B instead. The customer gets a suggestion on every deploy, just a different one. This defeats the anti-annoyance intent.
- **Hardcoded 24h cooldown TTL.** No adaptation to customer deploy frequency.
- **Cooldown is recorded before the customer sees the suggestion.** If EA synthesis drops the suggestion text, the cooldown is burned for nothing.
- **`_fetch_preferences` only reads tone/language/working_hours from settings Redis.** The scheduling preference fields (`preferred_meeting_duration`, `preferred_hours`, `buffer_minutes`) are populated by `ProactiveStateStore` methods, not by the assembler — there's a gap where `CustomerPreferences` fields exist but the assembler doesn't fill them. Specialists that need them call the proactive store directly via the interaction context or fall back to None.

### Pre-existing failures (not introduced by this PR)
- `test_analytics.py` — `_app()` signature mismatch (1 test)
- `test_heartbeat.py` — time-dependent quiet_hours logic (4 tests)

## Test plan

- [x] 84 new/modified unit tests passing across finance, scheduling, workflow, personality, context, and delegation recording
- [x] 1328 total unit tests passing (excluding 5 pre-existing failures)
- [x] Edge cases: exact 2x deviation boundary, malformed calendar snapshots, broken Redis during preference recording, cooldown expiry
- [x] Docstring audit: all public methods on touched files documented
- [ ] Integration test with live Redis (manual)
- [ ] Load test ContextAssembler under concurrent interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)